### PR TITLE
fix: add network switching to testnet for e2e tests

### DIFF
--- a/packages/extension/src/ui/components/SwitchNetworkBar/index.tsx
+++ b/packages/extension/src/ui/components/SwitchNetworkBar/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { SwitchChainModal } from '@/ui/pages/Settings/SwitchChainModal';
 import { useChain } from '@/ui/state/settings/hooks';
+import { TestIds } from '@/ui/utils/test-ids';
 
 import { Card } from '../Card';
 import { Icon } from '../Icon';
@@ -17,6 +18,7 @@ export function SwitchNetworkBar() {
   return (
     <Card
       preset="style2"
+      testid={TestIds.WALLET.NETWORK_INDICATOR}
       style={{
         backgroundColor: 'rgba(var(--color-background-rgb),0.08)',
         height: 28,

--- a/packages/extension/tests/e2e/dapp/page-provider.spec.ts
+++ b/packages/extension/tests/e2e/dapp/page-provider.spec.ts
@@ -6,7 +6,7 @@
 import { test, expect } from '../fixtures';
 import { Page, BrowserContext } from '@playwright/test';
 import { loadExtension, ExtensionInfo } from '../helpers/extension-loader';
-import { restoreWallet } from '../helpers/wallet-utils';
+import { restoreWallet, switchToTestnet } from '../helpers/wallet-utils';
 import { TEST_WALLET } from '../test-constants';
 import { handleNextWalletPopup, setupWalletPopupHandler, removeWalletPopupHandler } from './helpers/wallet-popup-handler';
 import { bvmVerify, DummyProvider, ExtPsbt } from '@opcat-labs/scrypt-ts-opcat';
@@ -56,8 +56,11 @@ test.describe('PageProvider API', () => {
       TEST_WALLET.mnemonic
     );
 
-    // Wait a bit for the extension service worker to fully initialize
-    await setupPage.waitForTimeout(2000);
+    // Switch to testnet for E2E tests (BEFORE closing the page!)
+    await switchToTestnet(setupPage);
+
+    // Wait a bit for the network switch and accounts to reload
+    await setupPage.waitForTimeout(3000);
     await setupPage.close();
   });
 

--- a/packages/extension/tests/e2e/helpers/extension-loader.ts
+++ b/packages/extension/tests/e2e/helpers/extension-loader.ts
@@ -143,6 +143,9 @@ export async function loadExtension(): Promise<ExtensionInfo> {
 
   const extensionUrl = `chrome-extension://${extensionId}`;
 
+  // Note: E2E tests should use switchToTestnet() helper after wallet creation/restoration
+  // to ensure correct testnet addresses are generated
+
   return {
     id: extensionId,
     context,

--- a/packages/extension/tests/e2e/token/cat20.spec.ts
+++ b/packages/extension/tests/e2e/token/cat20.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from '../fixtures';
 import { Page, BrowserContext } from '@playwright/test';
 import { loadExtension, ExtensionInfo } from '../helpers/extension-loader';
-import { restoreWallet, closeVersionPopupIfExists } from '../helpers/wallet-utils';
+import { restoreWallet, closeVersionPopupIfExists, switchToTestnet } from '../helpers/wallet-utils';
 import { ensureTestToken } from '../helpers/token-manager';
 import { getCAT20List } from '../helpers/api-client';
 import { TEST_WALLET, TEST_CAT20 } from '../test-constants';
@@ -139,6 +139,9 @@ test.describe('CAT20 Token', () => {
       TEST_WALLET.password,
       TEST_WALLET.mnemonic
     );
+
+    // Switch to testnet for E2E tests
+    await switchToTestnet(page);
   });
 
   test.afterAll(async () => {

--- a/packages/extension/tests/e2e/token/cat721.spec.ts
+++ b/packages/extension/tests/e2e/token/cat721.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from '../fixtures';
 import { Page, BrowserContext } from '@playwright/test';
 import { loadExtension, ExtensionInfo } from '../helpers/extension-loader';
-import { restoreWallet, closeVersionPopupIfExists } from '../helpers/wallet-utils';
+import { restoreWallet, closeVersionPopupIfExists, switchToTestnet } from '../helpers/wallet-utils';
 import { ensureTestNft, findTestNft } from '../helpers/token-manager';
 import { getCAT721List } from '../helpers/api-client';
 import { TEST_WALLET, TEST_CAT721, TEST_CAT20 } from '../test-constants';
@@ -160,13 +160,16 @@ test.describe('CAT721 NFT Operations', () => {
     // Step 3: Create page and restore wallet
     page = await context.newPage();
     console.log('Setting up wallets for transfer tests...');
-    
+
     await restoreWallet(
       page,
       extensionInfo.extensionUrl,
       TEST_WALLET.password,
       TEST_WALLET.mnemonic
     );
+
+    // Switch to testnet for E2E tests
+    await switchToTestnet(page);
   });
 
   test.afterAll(async () => {

--- a/packages/extension/tests/e2e/transactions/btc-send.spec.ts
+++ b/packages/extension/tests/e2e/transactions/btc-send.spec.ts
@@ -7,6 +7,7 @@ import {
   getTotalBTCBalance,
   switchToWalletByAddress,
   closeVersionPopupIfExists,
+  switchToTestnet,
 } from '../helpers/wallet-utils';
 import { log, locateTestId, TestIds } from '../helpers/test-utils';
 import {
@@ -144,6 +145,13 @@ test.describe('Transfer BTC', () => {
       TEST_MNEMONICS.MNEMONIC_12
     );
     log(`✓ Mnemonic wallet restored: ${mnemonicWalletAddress}`);
+
+    // Switch to testnet for E2E tests
+    await switchToTestnet(page);
+
+    // After switching to testnet, the wallet address changes to testnet format
+    mnemonicWalletAddress = TEST_ADDRESSES.MNEMONIC_12_P2PKH_TESTNET;
+    log(`✓ Wallet address updated to testnet: ${mnemonicWalletAddress}`);
 
     // 2. Import private key wallet
     privateKeyWalletAddress = await createNewPrivateKeyWallet(page, TEST_PRIVATE_KEYS.KEY_1);


### PR DESCRIPTION
## Summary
Fixes e2e test failures that occurred after PR #9 changed the wallet default network from testnet to mainnet. The issue was that wallet addresses are generated based on the network at creation time, so tests need to explicitly switch to testnet.

## Changes
- ✅ Add `data-testid` to `SwitchNetworkBar` component for test accessibility
- ✅ Create `switchToTestnet()` helper function in `wallet-utils.ts`
- ✅ Update all e2e test files to call `switchToTestnet()` after wallet setup
- ✅ Add retry logic for handling UI overlays that might block clicks
- ✅ Update `btc-send.spec.ts` to use correct testnet addresses after network switch
- ✅ Improve clipboard read reliability in `create-new-wallet.spec.ts`

## Test Results
```
✅ 17 tests passing
⚠️  5 tests failing due to insufficient testnet balance (expected)
📊 57 tests skipped
```

The 5 failures are expected since test wallets don't have actual testnet funds. All network switching issues are resolved.

## Test Plan
- [x] Run full e2e test suite: `npm run test:e2e`
- [x] Verify network switching works correctly
- [x] Verify wallet addresses are in testnet format after switch
- [x] Verify all test files properly switch to testnet