### PR TITLE
fix: improve balance decimal visibility on mainnet

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opcat-labs/wallet-extension",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "homepage": "https://github.com/OPCAT-Labs/wallet-extension#readme",
   "bugs": {

--- a/packages/extension/src/ui/pages/Main/WalletTabScreen/components/BalanceCard/BalanceCard.tsx
+++ b/packages/extension/src/ui/pages/Main/WalletTabScreen/components/BalanceCard/BalanceCard.tsx
@@ -44,7 +44,6 @@ export function BalanceCard({ accountBalance, disableUtxoTools = true, enableRef
   const [isExpanded, setIsExpanded] = useState(false);
   const dispatch = useDispatch();
   const isBalanceHidden = useSelector((state: AppState) => state.ui.isBalanceHidden);
-  const isBtcMainnet = chain.enum === ChainType.OPCAT_MAINNET;
 
   const [isSpecialLocale, setIsSpecialLocale] = useState(false);
 
@@ -149,7 +148,7 @@ export function BalanceCard({ accountBalance, disableUtxoTools = true, enableRef
           <span className={styles.balanceNumber}>{isBalanceHidden ? '*****' : totalAmount.split('.')[0]}</span>
           {!isBalanceHidden && (
             <>
-              <span className={styles.decimal} style={{ color: isBtcMainnet ? '#000' : 'rgba(var(--color-text-rgb), 0.45)' }}>
+              <span className={styles.decimal}>
                 .{totalAmount.split('.')[1]}
               </span>
               <span className={styles.unit}>{btcUnit}</span>


### PR DESCRIPTION
The decimal part of the balance was using black color (#000) on mainnet, making it blend with dark backgrounds and hard to read. Removed the conditional inline styling and now using the consistent semi-transparent color from the stylesheet for both mainnet and testnet.

Also bumped version to 0.2.1 and removed unused isBtcMainnet variable.