### PR TITLE
ci: update claude-pr-review workflow to use common-tools

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   claude-review:
-    uses: OPCAT-Labs/internal/.github/workflows/claude-pr-review.yml@main
+    uses: OPCAT-Labs/common-tools/.github/workflows/claude-pr-review.yml@main
     secrets:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Migrate reusable workflow reference from `OPCAT-Labs/internal` to `OPCAT-Labs/common-tools`
- Add explicit `permissions` block (`contents: read`, `pull-requests: write`)
- Standardize workflow to match the org-wide template

## Test plan
- [ ] Verify workflow triggers on PR events
- [ ] Confirm secrets pass through correctly