### PR TITLE
fix: align wallet tests and local e2e runner

### DIFF
--- a/packages/extension/tests/e2e/helpers/extension-loader.ts
+++ b/packages/extension/tests/e2e/helpers/extension-loader.ts
@@ -10,6 +10,13 @@ export interface ExtensionInfo {
 
 // Store console messages for debugging
 const consoleMessages: { type: string; text: string; location: string }[] = [];
+function resolveChromeExecutablePath(): string | undefined {
+  const envPath = process.env.PW_CHROME_EXECUTABLE_PATH || process.env.CHROME_EXECUTABLE_PATH;
+  if (envPath && fs.existsSync(envPath)) {
+    return envPath;
+  }
+  return undefined;
+}
 
 /**
  * Setup console listener on a page to capture all console messages
@@ -83,10 +90,12 @@ export async function loadExtension(): Promise<ExtensionInfo> {
 
   // Create a temporary user data directory
   const userDataDir = path.resolve(__dirname, '../test-user-data/test-user-data-' + Date.now());
+  const executablePath = resolveChromeExecutablePath();
 
   // Launch Chrome with the extension
   const context = await chromium.launchPersistentContext(userDataDir, {
     headless: false,
+    executablePath,
     args: [
       `--disable-extensions-except=${extensionPath}`,
       `--load-extension=${extensionPath}`,

--- a/packages/utils/src/keyring/simple-keyring.ts
+++ b/packages/utils/src/keyring/simple-keyring.ts
@@ -78,6 +78,9 @@ export class SimpleKeyring extends EventEmitter {
   async signData(publicKey: string, data: string, type: 'ecdsa' = 'ecdsa') {
     const keyPair = this._getPrivateKeyFor(publicKey);
     if (type === 'ecdsa') {
+      if (!/^[0-9a-fA-F]{64}$/.test(data)) {
+        throw new Error('Expected Hash');
+      }
       return keyPair.sign(Buffer.from(data, 'hex')).toString('hex');
     }
     throw new Error('Not support type');

--- a/packages/utils/src/message/ecdsa.ts
+++ b/packages/utils/src/message/ecdsa.ts
@@ -10,22 +10,17 @@ export function signMessageOfECDSA(privateKey: ECPairInterface, text: string) {
 export function verifyMessageOfECDSA(publicKey: string, text: string, sig: string) {
   const message = new bitcore.Message(text);
 
-  const signature = bitcore.crypto.Signature.fromCompact(Buffer.from(sig, 'base64'));
-  const hash = message.magicHash();
+  try {
+    const signature = bitcore.crypto.Signature.fromCompact(Buffer.from(sig, 'base64'));
+    const hash = message.magicHash();
+    const pubkeyInSig = bitcore.crypto.ECDSA.recoverPublicKey(hash, signature);
 
-  // recover the public key
-  const ecdsa = new bitcore.crypto.ECDSA();
-  ecdsa.hashbuf = hash;
-  ecdsa.sig = signature;
+    if (pubkeyInSig.toString() !== publicKey) {
+      return false;
+    }
 
-  const pubkeyInSig = ecdsa.toPublicKey();
-
-  const pubkeyInSigString = new bitcore.PublicKey(
-    Object.assign({}, pubkeyInSig.toObject(), { compressed: true })
-  ).toString();
-  if (pubkeyInSigString != publicKey) {
+    return bitcore.crypto.ECDSA.verify(hash, signature, pubkeyInSig);
+  } catch {
     return false;
   }
-
-  return bitcore.crypto.ECDSA.verify(hash, signature, pubkeyInSig);
 }


### PR DESCRIPTION
## Summary
- fix ECDSA verification against current bitcore-lib API
- restore hash validation behavior for signData unit tests
- allow optional Playwright executable override while keeping CI/default behavior unchanged

## Verification
- corepack yarn workspace @opcat-labs/wallet-sdk test
- corepack yarn build
- corepack yarn workspace @opcat-labs/wallet-extension test:e2e
