### PR TITLE
fix: SmallPay fee estimation using ExtPsbt and finalize unfinalized inputs

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opcat-labs/wallet-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "homepage": "https://github.com/OPCAT-Labs/wallet-extension#readme",
   "bugs": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opcat-labs/wallet-extension",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "homepage": "https://github.com/OPCAT-Labs/wallet-extension#readme",
   "bugs": {

--- a/packages/extension/src/background/controller/provider/controller.ts
+++ b/packages/extension/src/background/controller/provider/controller.ts
@@ -10,7 +10,7 @@ import { ethErrors } from 'eth-rpc-errors';
 import BaseController from '../base';
 import wallet from '../wallet';
 
-import { psbtFromHex } from '@/background/utils/psbt';
+import { psbtFromHex, estimatePsbtFeeInfo } from '@/background/utils/psbt';
 import { formatPsbtHex } from '@/ui/utils/psbt-utils';
 
 
@@ -472,7 +472,7 @@ class ProviderController extends BaseController {
       throw new Error('SmallPay only supports P2PKH wallets');
     }
 
-    // Analyze inputs: calculate wallet input value
+    // Analyze inputs: calculate wallet input value and total input value
     // Uses ExtPsbt.getInputOutput() which handles opcat layer's custom UTXO encoding
     let walletInputValue = 0n;
     const walletScriptHex = walletScript.toString('hex');
@@ -532,11 +532,9 @@ class ProviderController extends BaseController {
     }
     const amount = Number(userNetCost);
 
-    // Estimate fee rate using P2PKH input size (148 bytes per input, 34 per output, 10 overhead)
+    // Estimate fee using ExtPsbt's proper size calculation (handles data/OP_RETURN outputs)
+    const { feeRate } = estimatePsbtFeeInfo(psbtHex);
     const toSignInputs = await wallet.formatOptionsToSignInputs(psbt, params.options);
-    const walletInputCount = toSignInputs.length;
-    const estimatedVsize = walletInputCount * 148 + psbt.txOutputs.length * 34 + 10;
-    const feeRate = amount > 0 ? amount / estimatedVsize : 0;
 
     // Validate the payment
     const validation = wallet.validateSmallPayment(origin, amount, feeRate);
@@ -579,6 +577,18 @@ class ProviderController extends BaseController {
     const autoFinalized = params.options?.autoFinalized !== false;
     await wallet.signPsbt(psbt, toSignInputs, autoFinalized);
     const signedPsbtHex = psbt.toHex();
+
+    // Finalize any remaining unfinalized inputs (e.g., dApp-signed inputs)
+    for (let i = 0; i < psbt.data.inputs.length; i++) {
+      const input = psbt.data.inputs[i];
+      if (!input.finalScriptSig && !input.finalScriptWitness) {
+        try {
+          psbt.finalizeInput(i);
+        } catch {
+          // Input may not be ready to finalize — extractTransaction will catch this
+        }
+      }
+    }
 
     // Extract transaction and broadcast
     let txid: string;

--- a/packages/extension/src/background/utils/psbt.ts
+++ b/packages/extension/src/background/utils/psbt.ts
@@ -1,4 +1,4 @@
-import { Psbt } from '@opcat-labs/scrypt-ts-opcat';
+import { Psbt, ExtPsbt } from '@opcat-labs/scrypt-ts-opcat';
 import { bitcoin } from '@opcat-labs/wallet-sdk/lib/bitcoin-core';
 
 export function psbtFromHex<T=bitcoin.Psbt>(hex: string): T {
@@ -19,4 +19,25 @@ export function psbtFromBase64<T=bitcoin.Psbt>(base64: string): T {
     //     // error = e as Error
     // }
     return Psbt.fromBase64(base64) as T
+}
+
+/**
+ * Estimate PSBT size and fee info using ExtPsbt's calculation.
+ * Creates a temporary ExtPsbt for estimation only — does not affect signing.
+ *
+ * ExtPsbt.estimateSize() properly handles:
+ * - Output sizes including data fields (OP_RETURN, opcat data)
+ * - P2PKH input signature size prediction (73 + 33 + varint)
+ * - Proper varint-encoded input/output counts and tx overhead
+ */
+export function estimatePsbtFeeInfo(psbtHex: string): {
+  estimatedSize: number;
+  actualFee: number;
+  feeRate: number;
+} {
+  const extPsbt = ExtPsbt.fromHex(psbtHex);
+  const estimatedSize = extPsbt.estimateSize();
+  const actualFee = Number(extPsbt.inputAmount - extPsbt.outputAmount);
+  const feeRate = estimatedSize > 0 ? actualFee / estimatedSize : 0;
+  return { estimatedSize, actualFee, feeRate };
 }


### PR DESCRIPTION
## Summary
- Add `estimatePsbtFeeInfo()` utility using `ExtPsbt.estimateSize()` to properly estimate PSBT size, accounting for data/OP_RETURN outputs
- Replace manual hardcoded size calculation (34 bytes/output, 148 bytes/input) with ExtPsbt's proper estimation
- Calculate actual tx fee (`totalInput - totalOutput`) instead of `userNetCost`
- Finalize remaining unfinalized inputs before `extractTransaction()` to fix "Not finalized" error with multi-party PSBTs
- Bump version to 1.2.0

## Test plan
- [ ] Verify SmallPay auto-payment works for standard P2PKH transactions
- [ ] Verify SmallPay correctly handles PSBTs with data/OP_RETURN outputs
- [ ] Verify fee rate validation passes for valid transactions
- [ ] Verify fallback to approval popup when fee rate exceeds limits
- [ ] Verify multi-party PSBTs (dApp-signed + wallet-signed inputs) no longer throw "Not finalized"