### PR TITLE
feat(security): restrict OPCAT layer transfer destinations to P2PKH

### DIFF
--- a/packages/extension/src/background/controller/wallet.ts
+++ b/packages/extension/src/background/controller/wallet.ts
@@ -42,7 +42,7 @@ import {
 import { getChainInfo } from '@/shared/utils';
 import { psbtFromString } from '@/ui/utils/psbt-utils';
 import { txHelpers } from '@opcat-labs/wallet-sdk';
-import { isValidAddress, publicKeyToAddress, scriptPkToAddress } from '@opcat-labs/wallet-sdk/lib/address';
+import { isP2PKHAddress, publicKeyToAddress, scriptPkToAddress } from '@opcat-labs/wallet-sdk/lib/address';
 import { bitcoin, ECPair } from '@opcat-labs/wallet-sdk/lib/bitcoin-core';
 import { ExtPsbt, Signer, SignOptions, SupportedNetwork, UTXO as ExtUtxo, Transaction, OpenApiProvider } from '@opcat-labs/scrypt-ts-opcat';
 import {mergeSendToken, singleSendNft, toTokenOwnerAddress} from '@opcat-labs/cat-sdk'
@@ -891,8 +891,8 @@ export class WalletController extends BaseController {
       throw new Error('Insufficient balance.');
     }
 
-    if (!isValidAddress(to, networkType)) {
-      throw new Error('Invalid address.');
+    if (!isP2PKHAddress(to, networkType)) {
+      throw new Error('Invalid address. OPCAT layer only supports P2PKH addresses.');
     }
     // Convert wallet UTXOs to ExtUtxo format
     const extUtxos: ExtUtxo[] = btcUtxos.map((utxo) => ({
@@ -967,8 +967,8 @@ export class WalletController extends BaseController {
       throw new Error('Insufficient balance.');
     }
 
-    if (!isValidAddress(to, networkType)) {
-      throw new Error('Invalid address.');
+    if (!isP2PKHAddress(to, networkType)) {
+      throw new Error('Invalid address. OPCAT layer only supports P2PKH addresses.');
     }
     // Convert wallet UTXOs to ExtUtxo format
     const extUtxos: ExtUtxo[] = btcUtxos.map((utxo) => ({

--- a/packages/extension/src/ui/utils/index.ts
+++ b/packages/extension/src/ui/utils/index.ts
@@ -2,6 +2,9 @@ import { bech32 } from 'bech32';
 import BigNumber from 'bignumber.js';
 import { useLocation } from 'react-router-dom';
 
+import { isP2PKHAddress } from '@opcat-labs/wallet-sdk/lib/address';
+import { NetworkType } from '@opcat-labs/wallet-sdk/lib/network';
+
 export * from './hooks';
 export * from './WalletContext';
 export * from './test-ids';
@@ -116,9 +119,16 @@ export async function sleep(timeSec: number) {
   });
 }
 
-export function isValidAddress(address: string) {
+export function isValidAddress(address: string, networkType?: NetworkType) {
   if (!address) return false;
-  return true;
+  if (networkType !== undefined) {
+    return isP2PKHAddress(address, networkType);
+  }
+  // OPCAT layer only supports P2PKH; accept either network when not specified.
+  return (
+    isP2PKHAddress(address, NetworkType.MAINNET) ||
+    isP2PKHAddress(address, NetworkType.TESTNET)
+  );
 }
 
 export const copyToClipboard = (textToCopy: string | number) => {

--- a/packages/utils/src/address/index.ts
+++ b/packages/utils/src/address/index.ts
@@ -58,6 +58,21 @@ export function isValidAddress(address: string, networkType: NetworkType = Netwo
   return !error;
 }
 
+/**
+ * Check if the address is a valid P2PKH address for the given network.
+ * OPCAT layer only accepts P2PKH addresses as transfer destinations.
+ */
+export function isP2PKHAddress(address: string, networkType: NetworkType = NetworkType.MAINNET) {
+  if (!address) return false;
+  const network = toPsbtNetwork(networkType);
+  try {
+    const decoded = bitcoin.address.fromBase58Check(address);
+    return decoded.version === network.pubKeyHash;
+  } catch {
+    return false;
+  }
+}
+
 export function decodeAddress(address: string) {
   const mainnet = bitcoin.networks.bitcoin;
   const testnet = bitcoin.networks.testnet;

--- a/packages/utils/test/address/address.test.ts
+++ b/packages/utils/test/address/address.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { AddressType } from '../../src';
-import { decodeAddress, getAddressType, isValidAddress, publicKeyToAddress } from '../../src/address';
+import { decodeAddress, getAddressType, isP2PKHAddress, isValidAddress, publicKeyToAddress } from '../../src/address';
 import { NetworkType } from '../../src/network';
 import { LocalWallet } from '../../src/wallet';
 
@@ -134,5 +134,55 @@ describe('address', function () {
     expect(decodeAddress('bc1qxxx').addressType).eq(AddressType.UNKNOWN);
 
     expect(decodeAddress('').addressType).eq(AddressType.UNKNOWN);
+  });
+
+  describe('isP2PKHAddress (OPCAT layer transfer target constraint)', function () {
+    it('accepts P2PKH mainnet address on mainnet', function () {
+      expect(isP2PKHAddress(p2pkh_data.mainnet_address, NetworkType.MAINNET)).eq(true);
+    });
+
+    it('accepts P2PKH testnet address on testnet', function () {
+      expect(isP2PKHAddress(p2pkh_data.testnet_address, NetworkType.TESTNET)).eq(true);
+    });
+
+    it('rejects P2PKH mainnet address on testnet', function () {
+      expect(isP2PKHAddress(p2pkh_data.mainnet_address, NetworkType.TESTNET)).eq(false);
+    });
+
+    it('rejects P2PKH testnet address on mainnet', function () {
+      expect(isP2PKHAddress(p2pkh_data.testnet_address, NetworkType.MAINNET)).eq(false);
+    });
+
+    it('rejects P2SH mainnet address', function () {
+      expect(isP2PKHAddress(p2sh_data.mainnet_address, NetworkType.MAINNET)).eq(false);
+    });
+
+    it('rejects P2SH testnet address', function () {
+      expect(isP2PKHAddress(p2sh_data.testnet_address, NetworkType.TESTNET)).eq(false);
+    });
+
+    it('rejects P2WPKH (bech32) mainnet address', function () {
+      expect(isP2PKHAddress(p2wpkh_data.mainnet_address, NetworkType.MAINNET)).eq(false);
+    });
+
+    it('rejects P2WPKH (bech32) testnet address', function () {
+      expect(isP2PKHAddress(p2wpkh_data.testnet_address, NetworkType.TESTNET)).eq(false);
+    });
+
+    it('rejects P2TR (bech32m / taproot) mainnet address', function () {
+      expect(isP2PKHAddress(p2tr_data.mainnet_address, NetworkType.MAINNET)).eq(false);
+    });
+
+    it('rejects P2TR (bech32m / taproot) testnet address', function () {
+      expect(isP2PKHAddress(p2tr_data.testnet_address, NetworkType.TESTNET)).eq(false);
+    });
+
+    it('rejects empty string', function () {
+      expect(isP2PKHAddress('', NetworkType.MAINNET)).eq(false);
+    });
+
+    it('rejects garbage input', function () {
+      expect(isP2PKHAddress('not-an-address', NetworkType.MAINNET)).eq(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- OPCAT layer can only spend P2PKH outputs, so sends to P2SH / P2WPKH / P2WSH / P2TR addresses would either fail to broadcast or lock the recipient's funds. The previous validation only checked that the string decoded as *some* Bitcoin address.
- Added `isP2PKHAddress(address, networkType)` to the wallet SDK (Base58Check + P2PKH version byte check) and used it in `sendBTC` / `sendAllBTC`, with a clear error message.
- Promoted the UI-level `isValidAddress` stub (which used to accept any non-empty string) to use the same P2PKH check.
- Added unit tests covering P2PKH/P2SH/P2WPKH/P2TR on both networks, network mismatch, and malformed input.

## Test plan
- [x] `packages/utils`: `npx mocha -r ./node_modules/ts-node/register test/address/address.test.ts` — 18 passing, including 12 new `isP2PKHAddress` cases.
- [x] `packages/utils`: full `yarn build` succeeds and the new export is emitted in `lib/address/index.js`.
- [x] `packages/extension`: `npx tsc --noEmit` passes cleanly.
- [ ] Manual: open Send BTC, paste a bech32 address — send button stays disabled and background rejects with `Invalid address. OPCAT layer only supports P2PKH addresses.`
- [ ] Manual: paste a legacy (`1...` / `m...`) address — send proceeds normally.