### PR TITLE
Fix OPCAT dust change handling

### DIFF
--- a/packages/utils/src/address/index.ts
+++ b/packages/utils/src/address/index.ts
@@ -1,5 +1,5 @@
 import { bitcoin } from '../bitcoin-core';
-import { UTXO_DUST } from '../constants';
+import { getUtxoDustThreshold } from '../constants';
 import { NetworkType, toPsbtNetwork } from '../network';
 import { AddressType } from '../types';
 
@@ -74,7 +74,7 @@ export function isP2PKHAddress(address: string, networkType: NetworkType = Netwo
   }
 }
 
-export function decodeAddress(address: string) {
+export function decodeAddress(address: string, isOpcat = false) {
   const mainnet = bitcoin.networks.bitcoin;
   const testnet = bitcoin.networks.testnet;
   const regtest = bitcoin.networks.regtest;
@@ -95,7 +95,7 @@ export function decodeAddress(address: string) {
       return {
         networkType,
         addressType,
-        dust: getAddressTypeDust(addressType)
+        dust: getAddressTypeDust(addressType, isOpcat)
       };
     } catch (e) {}
   } else {
@@ -111,11 +111,11 @@ export function decodeAddress(address: string) {
         // do not work
         networkType = NetworkType.REGTEST;
         addressType = AddressType.P2PKH;
-      } 
+      }
       return {
         networkType,
         addressType,
-        dust: getAddressTypeDust(addressType)
+        dust: getAddressTypeDust(addressType, isOpcat)
       };
     } catch (e) {}
   }
@@ -123,12 +123,15 @@ export function decodeAddress(address: string) {
   return {
     networkType: NetworkType.MAINNET,
     addressType: AddressType.UNKNOWN,
-    dust: UTXO_DUST
+    dust: getUtxoDustThreshold(isOpcat)
   };
 }
 
-function getAddressTypeDust(addressType: AddressType) {
-  return UTXO_DUST;
+function getAddressTypeDust(addressType: AddressType, isOpcat = false) {
+  if (addressType === AddressType.P2PKH) {
+    return getUtxoDustThreshold(isOpcat);
+  }
+  return getUtxoDustThreshold(isOpcat);
 }
 
 /**

--- a/packages/utils/src/address/index.ts
+++ b/packages/utils/src/address/index.ts
@@ -1,5 +1,5 @@
 import { bitcoin } from '../bitcoin-core';
-import { getUtxoDustThreshold } from '../constants';
+import { ChainType, getUtxoDustThreshold } from '../constants';
 import { NetworkType, toPsbtNetwork } from '../network';
 import { AddressType } from '../types';
 
@@ -74,7 +74,7 @@ export function isP2PKHAddress(address: string, networkType: NetworkType = Netwo
   }
 }
 
-export function decodeAddress(address: string, isOpcat = false) {
+export function decodeAddress(address: string, chainType: ChainType = ChainType.BITCOIN) {
   const mainnet = bitcoin.networks.bitcoin;
   const testnet = bitcoin.networks.testnet;
   const regtest = bitcoin.networks.regtest;
@@ -95,7 +95,7 @@ export function decodeAddress(address: string, isOpcat = false) {
       return {
         networkType,
         addressType,
-        dust: getAddressTypeDust(addressType, isOpcat)
+        dust: getAddressTypeDust(addressType, chainType)
       };
     } catch (e) {}
   } else {
@@ -115,7 +115,7 @@ export function decodeAddress(address: string, isOpcat = false) {
       return {
         networkType,
         addressType,
-        dust: getAddressTypeDust(addressType, isOpcat)
+        dust: getAddressTypeDust(addressType, chainType)
       };
     } catch (e) {}
   }
@@ -123,15 +123,15 @@ export function decodeAddress(address: string, isOpcat = false) {
   return {
     networkType: NetworkType.MAINNET,
     addressType: AddressType.UNKNOWN,
-    dust: getUtxoDustThreshold(isOpcat)
+    dust: getUtxoDustThreshold(chainType)
   };
 }
 
-function getAddressTypeDust(addressType: AddressType, isOpcat = false) {
+function getAddressTypeDust(addressType: AddressType, chainType: ChainType = ChainType.BITCOIN) {
   if (addressType === AddressType.P2PKH) {
-    return getUtxoDustThreshold(isOpcat);
+    return getUtxoDustThreshold(chainType);
   }
-  return getUtxoDustThreshold(isOpcat);
+  return getUtxoDustThreshold(chainType);
 }
 
 /**

--- a/packages/utils/src/address/index.ts
+++ b/packages/utils/src/address/index.ts
@@ -1,4 +1,5 @@
 import { bitcoin } from '../bitcoin-core';
+import { UTXO_DUST } from '../constants';
 import { NetworkType, toPsbtNetwork } from '../network';
 import { AddressType } from '../types';
 
@@ -122,12 +123,12 @@ export function decodeAddress(address: string) {
   return {
     networkType: NetworkType.MAINNET,
     addressType: AddressType.UNKNOWN,
-    dust: 546
+    dust: UTXO_DUST
   };
 }
 
 function getAddressTypeDust(addressType: AddressType) {
-  return 546;
+  return UTXO_DUST;
 }
 
 /**

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,9 +1,18 @@
 export const BITCOIN_UTXO_DUST = 546;
 export const OPCAT_UTXO_DUST = 1;
 
-// Default to Bitcoin policy. OPCAT callers must opt into the 1-sat policy explicitly.
+export enum ChainType {
+  BITCOIN = 'bitcoin',
+  OPCAT = 'opcat'
+}
+
+// Default to Bitcoin policy. OPCAT callers must select the OPCAT chain policy explicitly.
 export const UTXO_DUST = BITCOIN_UTXO_DUST;
 
-export function getUtxoDustThreshold(isOpcat = false) {
-  return isOpcat ? OPCAT_UTXO_DUST : BITCOIN_UTXO_DUST;
+export function getChainTypeFromOpcatFlag(isOpcat = false) {
+  return isOpcat ? ChainType.OPCAT : ChainType.BITCOIN;
+}
+
+export function getUtxoDustThreshold(chainType: ChainType = ChainType.BITCOIN) {
+  return chainType === ChainType.OPCAT ? OPCAT_UTXO_DUST : BITCOIN_UTXO_DUST;
 }

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -13,6 +13,17 @@ export function getChainTypeFromOpcatFlag(isOpcat = false) {
   return isOpcat ? ChainType.OPCAT : ChainType.BITCOIN;
 }
 
+export function resolveChainType({
+  chainType,
+  isOpcat
+}: {
+  chainType?: ChainType;
+  /** @deprecated Use chainType instead. */
+  isOpcat?: boolean;
+} = {}) {
+  return chainType || getChainTypeFromOpcatFlag(isOpcat);
+}
+
 export function getUtxoDustThreshold(chainType: ChainType = ChainType.BITCOIN) {
   return chainType === ChainType.OPCAT ? OPCAT_UTXO_DUST : BITCOIN_UTXO_DUST;
 }

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,5 +1,7 @@
 export const BITCOIN_UTXO_DUST = 546;
 export const OPCAT_UTXO_DUST = 1;
+export const RBF_SEQUENCE = 0xfffffffd;
+export const FINAL_SEQUENCE = 0xffffffff;
 
 export enum ChainType {
   BITCOIN = 'bitcoin',

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,2 +1,2 @@
-// Default UTXO_DUST, this is usually sufficient, but for more precise cases, please use the getAddressUtxoDust method to obtain
-export const UTXO_DUST = 546;
+// OPCAT relay policy allows 1-sat UTXOs; do not use Bitcoin Core's 546-sat dust floor.
+export const UTXO_DUST = 1;

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,2 +1,9 @@
-// OPCAT relay policy allows 1-sat UTXOs; do not use Bitcoin Core's 546-sat dust floor.
-export const UTXO_DUST = 1;
+export const BITCOIN_UTXO_DUST = 546;
+export const OPCAT_UTXO_DUST = 1;
+
+// Default to Bitcoin policy. OPCAT callers must opt into the 1-sat policy explicitly.
+export const UTXO_DUST = BITCOIN_UTXO_DUST;
+
+export function getUtxoDustThreshold(isOpcat = false) {
+  return isOpcat ? OPCAT_UTXO_DUST : BITCOIN_UTXO_DUST;
+}

--- a/packages/utils/src/transaction/transaction.ts
+++ b/packages/utils/src/transaction/transaction.ts
@@ -27,7 +27,7 @@ interface TxOutput {
 /**
  * Convert UnspentOutput to PSBT TxInput
  */
-function utxoToInput(utxo: UnspentOutput, estimate?: boolean): TxInput {  
+function utxoToInput(utxo: UnspentOutput, estimate?: boolean): TxInput {
   if (utxo.addressType === AddressType.P2PKH) {
     if (!utxo.rawtx || estimate) {
       const data = {
@@ -71,6 +71,7 @@ export class Transaction {
   private _cacheNetworkFee = 0;
   private _cacheBtcUtxos: UnspentOutput[] = [];
   private _cacheToSignInputs: ToSignInput[] = [];
+  private dustThreshold = UTXO_DUST;
   constructor() {}
 
   setNetworkType(network: NetworkType) {
@@ -87,6 +88,10 @@ export class Transaction {
 
   setChangeAddress(address: string) {
     this.changedAddress = address;
+  }
+
+  setDustThreshold(dustThreshold: number) {
+    this.dustThreshold = dustThreshold;
   }
 
   addInput(utxo: UnspentOutput) {
@@ -211,6 +216,7 @@ export class Transaction {
     tx.setFeeRate(this.feeRate);
     tx.setEnableRBF(this.enableRBF);
     tx.setChangeAddress(this.changedAddress);
+    tx.setDustThreshold(this.dustThreshold);
     tx.utxos = this.utxos.map((v) => Object.assign({}, v));
     tx.inputs = this.inputs.map((v) => v);
     tx.outputs = this.outputs.map((v) => v);
@@ -297,7 +303,7 @@ export class Transaction {
     }
 
     const changeAmount = this.getTotalInput() - this.getTotalOutput() - Math.ceil(this._cacheNetworkFee);
-    if (changeAmount >= UTXO_DUST) {
+    if (changeAmount >= this.dustThreshold) {
       this.removeChangeOutput();
       this.addChangeOutput(changeAmount);
     } else {

--- a/packages/utils/src/transaction/transaction.ts
+++ b/packages/utils/src/transaction/transaction.ts
@@ -1,6 +1,6 @@
 import { addressToScriptPk } from '../address';
 import { bitcoin } from '../bitcoin-core';
-import { ChainType, getUtxoDustThreshold } from '../constants';
+import { ChainType, RBF_SEQUENCE, getUtxoDustThreshold } from '../constants';
 import { ErrorCodes, WalletUtilsError } from '../error';
 import { NetworkType, toPsbtNetwork } from '../network';
 import { AddressType, ToSignInput, UnspentOutput } from '../types';
@@ -191,7 +191,7 @@ export class Transaction {
       }
       psbt.data.addInput(v.data);
       if (this.enableRBF) {
-        psbt.setInputSequence(index, 0xfffffffd);
+        psbt.setInputSequence(index, RBF_SEQUENCE);
       }
     });
     this.outputs.forEach((v) => {

--- a/packages/utils/src/transaction/transaction.ts
+++ b/packages/utils/src/transaction/transaction.ts
@@ -162,6 +162,9 @@ export class Transaction {
   }
 
   removeChangeOutput() {
+    if (this.changeOutputIndex < 0) {
+      return;
+    }
     this.outputs.splice(this.changeOutputIndex, 1);
     this.changeOutputIndex = -1;
   }
@@ -294,7 +297,7 @@ export class Transaction {
     }
 
     const changeAmount = this.getTotalInput() - this.getTotalOutput() - Math.ceil(this._cacheNetworkFee);
-    if (changeAmount > UTXO_DUST) {
+    if (changeAmount >= UTXO_DUST) {
       this.removeChangeOutput();
       this.addChangeOutput(changeAmount);
     } else {

--- a/packages/utils/src/transaction/transaction.ts
+++ b/packages/utils/src/transaction/transaction.ts
@@ -1,11 +1,12 @@
 import { addressToScriptPk } from '../address';
 import { bitcoin } from '../bitcoin-core';
-import { UTXO_DUST } from '../constants';
+import { ChainType, getUtxoDustThreshold } from '../constants';
 import { ErrorCodes, WalletUtilsError } from '../error';
 import { NetworkType, toPsbtNetwork } from '../network';
 import { AddressType, ToSignInput, UnspentOutput } from '../types';
 import { EstimateWallet } from '../wallet';
 import { utxoHelper } from './utxo';
+
 interface TxInput {
   data: {
     hash: string;
@@ -71,7 +72,7 @@ export class Transaction {
   private _cacheNetworkFee = 0;
   private _cacheBtcUtxos: UnspentOutput[] = [];
   private _cacheToSignInputs: ToSignInput[] = [];
-  private dustThreshold = UTXO_DUST;
+  private chainType = ChainType.BITCOIN;
   constructor() {}
 
   setNetworkType(network: NetworkType) {
@@ -90,8 +91,8 @@ export class Transaction {
     this.changedAddress = address;
   }
 
-  setDustThreshold(dustThreshold: number) {
-    this.dustThreshold = dustThreshold;
+  setChainType(chainType: ChainType) {
+    this.chainType = chainType;
   }
 
   addInput(utxo: UnspentOutput) {
@@ -216,7 +217,7 @@ export class Transaction {
     tx.setFeeRate(this.feeRate);
     tx.setEnableRBF(this.enableRBF);
     tx.setChangeAddress(this.changedAddress);
-    tx.setDustThreshold(this.dustThreshold);
+    tx.setChainType(this.chainType);
     tx.utxos = this.utxos.map((v) => Object.assign({}, v));
     tx.inputs = this.inputs.map((v) => v);
     tx.outputs = this.outputs.map((v) => v);
@@ -303,7 +304,7 @@ export class Transaction {
     }
 
     const changeAmount = this.getTotalInput() - this.getTotalOutput() - Math.ceil(this._cacheNetworkFee);
-    if (changeAmount >= this.dustThreshold) {
+    if (changeAmount >= getUtxoDustThreshold(this.chainType)) {
       this.removeChangeOutput();
       this.addChangeOutput(changeAmount);
     } else {

--- a/packages/utils/src/transaction/utxo.ts
+++ b/packages/utils/src/transaction/utxo.ts
@@ -1,5 +1,5 @@
 import { decodeAddress } from '../address';
-import { getUtxoDustThreshold } from '../constants';
+import { ChainType, getUtxoDustThreshold } from '../constants';
 import { NetworkType } from '../network';
 import { AddressType, UnspentOutput } from '../types';
 
@@ -44,17 +44,22 @@ function getAddedVirtualSize(addressType: AddressType) {
   throw new Error('unknown address type');
 }
 
-export function getUtxoDust(addressType: AddressType, isOpcat = false) {
+export function getUtxoDust(addressType: AddressType, chainType: ChainType = ChainType.BITCOIN) {
   if (addressType === AddressType.P2PKH) {
-    return getUtxoDustThreshold(isOpcat);
+    return getUtxoDustThreshold(chainType);
   }
-  return getUtxoDustThreshold(isOpcat);
+  return getUtxoDustThreshold(chainType);
 }
 
 // deprecated
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getAddressUtxoDust(address: string, networkType: NetworkType = NetworkType.MAINNET, isOpcat = false) {
-  return decodeAddress(address, isOpcat).dust;
+export function getAddressUtxoDust(
+  address: string,
+  networkType: NetworkType = NetworkType.MAINNET,
+  chainType: ChainType = ChainType.BITCOIN
+) {
+  void networkType;
+  return decodeAddress(address, chainType).dust;
 }
 
 export const utxoHelper = {

--- a/packages/utils/src/transaction/utxo.ts
+++ b/packages/utils/src/transaction/utxo.ts
@@ -1,9 +1,10 @@
 import { decodeAddress } from '../address';
-import { UTXO_DUST } from '../constants';
+import { getUtxoDustThreshold } from '../constants';
 import { NetworkType } from '../network';
 import { AddressType, UnspentOutput } from '../types';
 
 function hasAnyAssets(utxos: UnspentOutput[]) {
+  void utxos;
   return false;
 }
 
@@ -43,14 +44,17 @@ function getAddedVirtualSize(addressType: AddressType) {
   throw new Error('unknown address type');
 }
 
-export function getUtxoDust(addressType: AddressType) {
-  return UTXO_DUST;
+export function getUtxoDust(addressType: AddressType, isOpcat = false) {
+  if (addressType === AddressType.P2PKH) {
+    return getUtxoDustThreshold(isOpcat);
+  }
+  return getUtxoDustThreshold(isOpcat);
 }
 
 // deprecated
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getAddressUtxoDust(address: string, networkType: NetworkType = NetworkType.MAINNET) {
-  return decodeAddress(address).dust;
+export function getAddressUtxoDust(address: string, networkType: NetworkType = NetworkType.MAINNET, isOpcat = false) {
+  return decodeAddress(address, isOpcat).dust;
 }
 
 export const utxoHelper = {

--- a/packages/utils/src/transaction/utxo.ts
+++ b/packages/utils/src/transaction/utxo.ts
@@ -1,4 +1,5 @@
 import { decodeAddress } from '../address';
+import { UTXO_DUST } from '../constants';
 import { NetworkType } from '../network';
 import { AddressType, UnspentOutput } from '../types';
 
@@ -43,7 +44,7 @@ function getAddedVirtualSize(addressType: AddressType) {
 }
 
 export function getUtxoDust(addressType: AddressType) {
-  return 546;
+  return UTXO_DUST;
 }
 
 // deprecated

--- a/packages/utils/src/tx-helpers/send-btc.ts
+++ b/packages/utils/src/tx-helpers/send-btc.ts
@@ -1,13 +1,11 @@
-import { UTXO_DUST } from '../constants';
+import { ChainType, UTXO_DUST, getChainTypeFromOpcatFlag } from '../constants';
 import { ErrorCodes, WalletUtilsError } from '../error';
 import { NetworkType, toOpcatNetwork } from '../network';
 import { Transaction } from '../transaction/transaction';
 import { utxoHelper } from '../transaction/utxo';
 import { ToSignInput, UnspentOutput } from '../types';
-
 // import * as scryptOpCat from '@opcat-labs/scrypt-ts-opcat';
 // const { ExtPsbt, intToByteString, len } = scryptOpCat;
-
 import { ExtPsbt, intToByteString, len } from '@opcat-labs/scrypt-ts-opcat';
 
 function hexifyMemos(memos: string[]) {
@@ -25,8 +23,6 @@ function sendOpcatBtc({
   networkType,
   changeAddress,
   feeRate,
-  isOpcat,
-  enableRBF = true,
   memo,
   memos
 }: {
@@ -38,50 +34,49 @@ function sendOpcatBtc({
   networkType: NetworkType;
   changeAddress: string;
   feeRate: number;
-  isOpcat?: boolean
-  enableRBF?: boolean;
   memo?: string;
   memos?: string[];
 }) {
   const memoArr = memo ? [memo] : memos;
-  let memoStr = ''
+  let memoStr = '';
   if (memoArr && memoArr.length > 0 && memoArr[0]) {
-    let hexMemos = hexifyMemos(memoArr)
-    hexMemos.forEach(hexMemo => {
-      memoStr += intToByteString(len(hexMemo), BigInt(4)) + hexMemo
-    })
+    let hexMemos = hexifyMemos(memoArr);
+    hexMemos.forEach((hexMemo) => {
+      memoStr += intToByteString(len(hexMemo), BigInt(4)) + hexMemo;
+    });
   }
 
-  const extPsbt = new ExtPsbt({network: toOpcatNetwork(networkType)})
-    .spendUTXO(btcUtxos.map(v => ({
+  const extPsbt = new ExtPsbt({ network: toOpcatNetwork(networkType) }).spendUTXO(
+    btcUtxos.map((v) => ({
       txId: v.txid,
       outputIndex: v.vout,
       satoshis: v.satoshis,
       script: v.scriptPk,
       data: v.data || ''
-    })))
-  
+    }))
+  );
+
   if (tos.length > 0) {
     extPsbt.addOutput({
       address: tos[0].address,
       value: BigInt(tos[0].satoshis),
       data: Buffer.from(memoStr, 'hex')
-    })
+    });
   }
-    
-  tos.slice(1).forEach(v => {
+
+  tos.slice(1).forEach((v) => {
     extPsbt.addOutput({
       address: v.address,
       value: BigInt(v.satoshis),
       data: Buffer.alloc(0)
-    })
-  })
-  extPsbt.change(changeAddress, feeRate).seal()
+    });
+  });
+  extPsbt.change(changeAddress, feeRate).seal();
   const signInputs = extPsbt.psbtOptions().toSignInputs;
-  signInputs.forEach(v => {
-    v.publicKey = btcUtxos[v.index].pubkey
-  })
-  return {psbt: extPsbt, toSignInputs: signInputs}
+  signInputs.forEach((v) => {
+    v.publicKey = btcUtxos[v.index].pubkey;
+  });
+  return { psbt: extPsbt, toSignInputs: signInputs };
 }
 
 export async function sendBTC({
@@ -103,23 +98,22 @@ export async function sendBTC({
   networkType: NetworkType;
   changeAddress: string;
   feeRate: number;
-  isOpcat?: boolean
+  isOpcat?: boolean;
   enableRBF?: boolean;
   memo?: string;
   memos?: string[];
 }) {
-  if (isOpcat) {
+  const chainType = getChainTypeFromOpcatFlag(isOpcat);
+  if (chainType === ChainType.OPCAT) {
     return sendOpcatBtc({
       btcUtxos,
       tos,
       networkType,
       changeAddress,
       feeRate,
-      isOpcat,
-      enableRBF,
       memo,
       memos
-    })
+    });
   }
   if (utxoHelper.hasAnyAssets(btcUtxos)) {
     throw new WalletUtilsError(ErrorCodes.NOT_SAFE_UTXOS);
@@ -127,6 +121,7 @@ export async function sendBTC({
 
   const tx = new Transaction();
   tx.setNetworkType(networkType);
+  tx.setChainType(chainType);
   tx.setFeeRate(feeRate);
   tx.setEnableRBF(enableRBF);
   tx.setChangeAddress(changeAddress);
@@ -171,17 +166,15 @@ export async function sendAllBTC({
   isOpcat?: boolean;
   enableRBF?: boolean;
 }) {
-
-  if (isOpcat) {
+  const chainType = getChainTypeFromOpcatFlag(isOpcat);
+  if (chainType === ChainType.OPCAT) {
     return sendOpcatBtc({
       btcUtxos,
       tos: [],
       networkType,
       changeAddress: toAddress,
-      feeRate,
-      isOpcat,
-      enableRBF
-    })
+      feeRate
+    });
   }
 
   if (utxoHelper.hasAnyAssets(btcUtxos)) {
@@ -190,6 +183,7 @@ export async function sendAllBTC({
 
   const tx = new Transaction();
   tx.setNetworkType(networkType);
+  tx.setChainType(chainType);
   tx.setFeeRate(feeRate);
   tx.setEnableRBF(enableRBF);
   tx.addOutput(toAddress, UTXO_DUST);

--- a/packages/utils/src/tx-helpers/send-btc.ts
+++ b/packages/utils/src/tx-helpers/send-btc.ts
@@ -1,4 +1,4 @@
-import { ChainType, UTXO_DUST, getChainTypeFromOpcatFlag } from '../constants';
+import { ChainType, UTXO_DUST, resolveChainType } from '../constants';
 import { ErrorCodes, WalletUtilsError } from '../error';
 import { NetworkType, toOpcatNetwork } from '../network';
 import { Transaction } from '../transaction/transaction';
@@ -85,6 +85,7 @@ export async function sendBTC({
   networkType,
   changeAddress,
   feeRate,
+  chainType,
   isOpcat,
   enableRBF = true,
   memo,
@@ -98,13 +99,15 @@ export async function sendBTC({
   networkType: NetworkType;
   changeAddress: string;
   feeRate: number;
+  chainType?: ChainType;
+  /** @deprecated Use chainType instead. */
   isOpcat?: boolean;
   enableRBF?: boolean;
   memo?: string;
   memos?: string[];
 }) {
-  const chainType = getChainTypeFromOpcatFlag(isOpcat);
-  if (chainType === ChainType.OPCAT) {
+  const resolvedChainType = resolveChainType({ chainType, isOpcat });
+  if (resolvedChainType === ChainType.OPCAT) {
     return sendOpcatBtc({
       btcUtxos,
       tos,
@@ -121,7 +124,7 @@ export async function sendBTC({
 
   const tx = new Transaction();
   tx.setNetworkType(networkType);
-  tx.setChainType(chainType);
+  tx.setChainType(resolvedChainType);
   tx.setFeeRate(feeRate);
   tx.setEnableRBF(enableRBF);
   tx.setChangeAddress(changeAddress);
@@ -156,6 +159,7 @@ export async function sendAllBTC({
   toAddress,
   networkType,
   feeRate,
+  chainType,
   isOpcat,
   enableRBF = true
 }: {
@@ -163,11 +167,13 @@ export async function sendAllBTC({
   toAddress: string;
   networkType: NetworkType;
   feeRate: number;
+  chainType?: ChainType;
+  /** @deprecated Use chainType instead. */
   isOpcat?: boolean;
   enableRBF?: boolean;
 }) {
-  const chainType = getChainTypeFromOpcatFlag(isOpcat);
-  if (chainType === ChainType.OPCAT) {
+  const resolvedChainType = resolveChainType({ chainType, isOpcat });
+  if (resolvedChainType === ChainType.OPCAT) {
     return sendOpcatBtc({
       btcUtxos,
       tos: [],
@@ -183,7 +189,7 @@ export async function sendAllBTC({
 
   const tx = new Transaction();
   tx.setNetworkType(networkType);
-  tx.setChainType(chainType);
+  tx.setChainType(resolvedChainType);
   tx.setFeeRate(feeRate);
   tx.setEnableRBF(enableRBF);
   tx.addOutput(toAddress, UTXO_DUST);

--- a/packages/utils/src/tx-helpers/send-btc.ts
+++ b/packages/utils/src/tx-helpers/send-btc.ts
@@ -1,4 +1,4 @@
-import { ChainType, UTXO_DUST, resolveChainType } from '../constants';
+import { ChainType, FINAL_SEQUENCE, RBF_SEQUENCE, UTXO_DUST, resolveChainType } from '../constants';
 import { ErrorCodes, WalletUtilsError } from '../error';
 import { NetworkType, toOpcatNetwork } from '../network';
 import { Transaction } from '../transaction/transaction';
@@ -23,6 +23,7 @@ function sendOpcatBtc({
   networkType,
   changeAddress,
   feeRate,
+  enableRBF,
   memo,
   memos
 }: {
@@ -34,6 +35,7 @@ function sendOpcatBtc({
   networkType: NetworkType;
   changeAddress: string;
   feeRate: number;
+  enableRBF: boolean;
   memo?: string;
   memos?: string[];
 }) {
@@ -55,6 +57,10 @@ function sendOpcatBtc({
       data: v.data || ''
     }))
   );
+  const sequence = enableRBF ? RBF_SEQUENCE : FINAL_SEQUENCE;
+  extPsbt.txInputs.forEach((_, index) => {
+    extPsbt.setInputSequence(index, sequence);
+  });
 
   if (tos.length > 0) {
     extPsbt.addOutput({
@@ -114,6 +120,7 @@ export async function sendBTC({
       networkType,
       changeAddress,
       feeRate,
+      enableRBF,
       memo,
       memos
     });
@@ -179,7 +186,8 @@ export async function sendAllBTC({
       tos: [],
       networkType,
       changeAddress: toAddress,
-      feeRate
+      feeRate,
+      enableRBF
     });
   }
 

--- a/packages/utils/test/address/address.test.ts
+++ b/packages/utils/test/address/address.test.ts
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
 import { AddressType } from '../../src';
 import { decodeAddress, getAddressType, isP2PKHAddress, isValidAddress, publicKeyToAddress } from '../../src/address';
-import { BITCOIN_UTXO_DUST, OPCAT_UTXO_DUST } from '../../src/constants';
+import { BITCOIN_UTXO_DUST, ChainType, OPCAT_UTXO_DUST } from '../../src/constants';
 import { NetworkType } from '../../src/network';
 import { LocalWallet } from '../../src/wallet';
+import { expect } from 'chai';
 
 const p2wpkh_data = {
   pubkey: '02b602ad190efb7b4f520068e3f8ecf573823d9e2557c5229231b4e14b79bbc0d8',
@@ -127,7 +127,7 @@ describe('address', function () {
 
         it(`should return OPCAT dust for ${networkNames[networkType]} when requested`, function () {
           const address = LocalWallet.fromRandom(addressType, networkType).address;
-          const addressInfo = decodeAddress(address, true);
+          const addressInfo = decodeAddress(address, ChainType.OPCAT);
           expect(addressInfo.networkType).to.eq(networkType);
           expect(addressInfo.addressType).to.eq(addressType);
           expect(addressInfo.dust).to.eq(OPCAT_UTXO_DUST);
@@ -139,7 +139,7 @@ describe('address', function () {
   it('decodeAddress UNKNOWN', function () {
     expect(decodeAddress('invalid address').addressType).eq(AddressType.UNKNOWN);
     expect(decodeAddress('invalid address').dust).eq(BITCOIN_UTXO_DUST);
-    expect(decodeAddress('invalid address', true).dust).eq(OPCAT_UTXO_DUST);
+    expect(decodeAddress('invalid address', ChainType.OPCAT).dust).eq(OPCAT_UTXO_DUST);
 
     expect(decodeAddress('bc1qxxx').addressType).eq(AddressType.UNKNOWN);
 

--- a/packages/utils/test/address/address.test.ts
+++ b/packages/utils/test/address/address.test.ts
@@ -115,7 +115,7 @@ describe('address', function () {
   networks.forEach((networkType) => {
     describe('decodeAddress networkType: ' + networkNames[networkType], function () {
       const addressTypes = [AddressType.P2PKH];
-      const dusts = [546];
+      const dusts = [1];
       addressTypes.forEach((addressType, index) => {
         it(`should return ${networkNames[networkType]}`, function () {
           const address = LocalWallet.fromRandom(addressType, networkType).address;
@@ -130,6 +130,7 @@ describe('address', function () {
 
   it('decodeAddress UNKNOWN', function () {
     expect(decodeAddress('invalid address').addressType).eq(AddressType.UNKNOWN);
+    expect(decodeAddress('invalid address').dust).eq(1);
 
     expect(decodeAddress('bc1qxxx').addressType).eq(AddressType.UNKNOWN);
 

--- a/packages/utils/test/address/address.test.ts
+++ b/packages/utils/test/address/address.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { AddressType } from '../../src';
 import { decodeAddress, getAddressType, isP2PKHAddress, isValidAddress, publicKeyToAddress } from '../../src/address';
+import { BITCOIN_UTXO_DUST, OPCAT_UTXO_DUST } from '../../src/constants';
 import { NetworkType } from '../../src/network';
 import { LocalWallet } from '../../src/wallet';
 
@@ -94,7 +95,6 @@ describe('address', function () {
   });
 
   it('getAddressType', () => {
-
     expect(getAddressType(p2pkh_data.mainnet_address, NetworkType.MAINNET)).eq(
       AddressType.P2PKH,
       'mainnet address type should be p2pkh'
@@ -115,7 +115,7 @@ describe('address', function () {
   networks.forEach((networkType) => {
     describe('decodeAddress networkType: ' + networkNames[networkType], function () {
       const addressTypes = [AddressType.P2PKH];
-      const dusts = [1];
+      const dusts = [BITCOIN_UTXO_DUST];
       addressTypes.forEach((addressType, index) => {
         it(`should return ${networkNames[networkType]}`, function () {
           const address = LocalWallet.fromRandom(addressType, networkType).address;
@@ -124,13 +124,22 @@ describe('address', function () {
           expect(addressInfo.addressType).to.eq(addressType);
           expect(addressInfo.dust).to.eq(dusts[index]);
         });
+
+        it(`should return OPCAT dust for ${networkNames[networkType]} when requested`, function () {
+          const address = LocalWallet.fromRandom(addressType, networkType).address;
+          const addressInfo = decodeAddress(address, true);
+          expect(addressInfo.networkType).to.eq(networkType);
+          expect(addressInfo.addressType).to.eq(addressType);
+          expect(addressInfo.dust).to.eq(OPCAT_UTXO_DUST);
+        });
       });
     });
   });
 
   it('decodeAddress UNKNOWN', function () {
     expect(decodeAddress('invalid address').addressType).eq(AddressType.UNKNOWN);
-    expect(decodeAddress('invalid address').dust).eq(1);
+    expect(decodeAddress('invalid address').dust).eq(BITCOIN_UTXO_DUST);
+    expect(decodeAddress('invalid address', true).dust).eq(OPCAT_UTXO_DUST);
 
     expect(decodeAddress('bc1qxxx').addressType).eq(AddressType.UNKNOWN);
 

--- a/packages/utils/test/transaction/dust-policy.test.ts
+++ b/packages/utils/test/transaction/dust-policy.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import { AddressType, UnspentOutput } from '../../src';
+import { BITCOIN_UTXO_DUST, OPCAT_UTXO_DUST } from '../../src/constants';
+import { NetworkType } from '../../src/network';
+import { Transaction } from '../../src/transaction/transaction';
+import { LocalWallet } from '../../src/wallet';
+
+function genDummyUtxo(wallet: LocalWallet, satoshis: number): UnspentOutput {
+  return {
+    txid: '0000000000000000000000000000000000000000000000000000000000000000',
+    vout: 0,
+    satoshis,
+    scriptPk: wallet.scriptPk,
+    addressType: wallet.addressType,
+    pubkey: wallet.pubkey
+  };
+}
+
+async function buildTransaction({
+  fromWallet,
+  toWallet,
+  inputSatoshis,
+  outputSatoshis,
+  dustThreshold
+}: {
+  fromWallet: LocalWallet;
+  toWallet: LocalWallet;
+  inputSatoshis: number;
+  outputSatoshis: number;
+  dustThreshold?: number;
+}) {
+  const tx = new Transaction();
+  tx.setNetworkType(fromWallet.networkType);
+  tx.setFeeRate(1);
+  tx.setChangeAddress(fromWallet.address);
+  if (dustThreshold !== undefined) {
+    tx.setDustThreshold(dustThreshold);
+  }
+  tx.addOutput(toWallet.address, outputSatoshis);
+
+  const toSignInputs = await tx.addSufficientUtxosForFee([genDummyUtxo(fromWallet, inputSatoshis)]);
+  const psbt = tx.toPsbt();
+  await fromWallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any });
+  return {
+    psbt,
+    fee: Number(psbt.getFee())
+  };
+}
+
+describe('Transaction dust policy', function () {
+  const fromWallet = LocalWallet.fromRandom(AddressType.P2PKH, NetworkType.MAINNET);
+  const toWallet = LocalWallet.fromRandom(AddressType.P2PKH, NetworkType.MAINNET);
+
+  it('keeps OPCAT small positive change instead of sweeping it to fees', async function () {
+    const inputSatoshis = 603;
+    const outputSatoshis = 200;
+    const ret = await buildTransaction({
+      fromWallet,
+      toWallet,
+      inputSatoshis,
+      outputSatoshis,
+      dustThreshold: OPCAT_UTXO_DUST
+    });
+    const changeOutput = ret.psbt.txOutputs[1];
+
+    expect(ret.psbt.txInputs.length).eq(1);
+    expect(ret.psbt.txOutputs.length).eq(2);
+    expect(ret.psbt.txOutputs[0].value).eq(outputSatoshis);
+    expect(changeOutput.address).eq(fromWallet.address);
+    expect(changeOutput.value).eq(inputSatoshis - outputSatoshis - ret.fee);
+    expect(changeOutput.value).gt(0);
+    expect(changeOutput.value).lt(BITCOIN_UTXO_DUST);
+  });
+
+  it('uses the Bitcoin dust threshold by default', async function () {
+    const inputSatoshis = 603;
+    const outputSatoshis = 200;
+    const ret = await buildTransaction({
+      fromWallet,
+      toWallet,
+      inputSatoshis,
+      outputSatoshis
+    });
+    const remainingAfterFee = inputSatoshis - outputSatoshis - ret.fee;
+
+    expect(ret.psbt.txInputs.length).eq(1);
+    expect(ret.psbt.txOutputs.length).eq(1);
+    expect(ret.psbt.txOutputs[0].value).eq(outputSatoshis);
+    expect(remainingAfterFee).lt(BITCOIN_UTXO_DUST);
+  });
+});

--- a/packages/utils/test/transaction/dust-policy.test.ts
+++ b/packages/utils/test/transaction/dust-policy.test.ts
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
 import { AddressType, UnspentOutput } from '../../src';
-import { BITCOIN_UTXO_DUST, OPCAT_UTXO_DUST } from '../../src/constants';
+import { BITCOIN_UTXO_DUST, ChainType, OPCAT_UTXO_DUST, getUtxoDustThreshold } from '../../src/constants';
 import { NetworkType } from '../../src/network';
 import { Transaction } from '../../src/transaction/transaction';
 import { LocalWallet } from '../../src/wallet';
+import { expect } from 'chai';
 
 function genDummyUtxo(wallet: LocalWallet, satoshis: number): UnspentOutput {
   return {
@@ -21,35 +21,81 @@ async function buildTransaction({
   toWallet,
   inputSatoshis,
   outputSatoshis,
-  dustThreshold
+  chainType,
+  sign = true
 }: {
   fromWallet: LocalWallet;
   toWallet: LocalWallet;
   inputSatoshis: number;
   outputSatoshis: number;
-  dustThreshold?: number;
+  chainType?: ChainType;
+  sign?: boolean;
 }) {
   const tx = new Transaction();
   tx.setNetworkType(fromWallet.networkType);
   tx.setFeeRate(1);
   tx.setChangeAddress(fromWallet.address);
-  if (dustThreshold !== undefined) {
-    tx.setDustThreshold(dustThreshold);
+  if (chainType !== undefined) {
+    tx.setChainType(chainType);
   }
   tx.addOutput(toWallet.address, outputSatoshis);
 
   const toSignInputs = await tx.addSufficientUtxosForFee([genDummyUtxo(fromWallet, inputSatoshis)]);
+  const builderFee = inputSatoshis - outputSatoshis - tx.getChangeAmount();
   const psbt = tx.toPsbt();
-  await fromWallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any });
+  if (sign) {
+    await fromWallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any });
+  }
   return {
     psbt,
-    fee: Number(psbt.getFee())
+    builderFee,
+    changeAmount: tx.getChangeAmount(),
+    fee: sign ? Number(psbt.getFee()) : builderFee
+  };
+}
+
+async function buildTransactionWithFixedFee({
+  fromWallet,
+  toWallet,
+  outputSatoshis,
+  chainType,
+  targetChange,
+  networkFee = 200
+}: {
+  fromWallet: LocalWallet;
+  toWallet: LocalWallet;
+  outputSatoshis: number;
+  chainType?: ChainType;
+  targetChange: number;
+  networkFee?: number;
+}) {
+  const tx = new Transaction();
+  tx.setNetworkType(fromWallet.networkType);
+  tx.setFeeRate(1);
+  tx.setChangeAddress(fromWallet.address);
+  if (chainType !== undefined) {
+    tx.setChainType(chainType);
+  }
+  tx.addInput(genDummyUtxo(fromWallet, outputSatoshis + networkFee + targetChange));
+  tx.addOutput(toWallet.address, outputSatoshis);
+  tx.calNetworkFee = async () => networkFee;
+
+  await tx.addSufficientUtxosForFee([]);
+  return {
+    psbt: tx.toPsbt(),
+    changeAmount: tx.getChangeAmount()
   };
 }
 
 describe('Transaction dust policy', function () {
   const fromWallet = LocalWallet.fromRandom(AddressType.P2PKH, NetworkType.MAINNET);
   const toWallet = LocalWallet.fromRandom(AddressType.P2PKH, NetworkType.MAINNET);
+
+  it('resolves dust thresholds from the selected chain policy', function () {
+    expect(getUtxoDustThreshold()).eq(BITCOIN_UTXO_DUST);
+    expect(getUtxoDustThreshold(ChainType.BITCOIN)).eq(BITCOIN_UTXO_DUST);
+    expect(getUtxoDustThreshold(ChainType.OPCAT)).eq(OPCAT_UTXO_DUST);
+  });
 
   it('keeps OPCAT small positive change instead of sweeping it to fees', async function () {
     const inputSatoshis = 603;
@@ -59,7 +105,7 @@ describe('Transaction dust policy', function () {
       toWallet,
       inputSatoshis,
       outputSatoshis,
-      dustThreshold: OPCAT_UTXO_DUST
+      chainType: ChainType.OPCAT
     });
     const changeOutput = ret.psbt.txOutputs[1];
 
@@ -70,6 +116,22 @@ describe('Transaction dust policy', function () {
     expect(changeOutput.value).eq(inputSatoshis - outputSatoshis - ret.fee);
     expect(changeOutput.value).gt(0);
     expect(changeOutput.value).lt(BITCOIN_UTXO_DUST);
+  });
+
+  it('keeps OPCAT change at the exact 1-sat threshold', async function () {
+    const outputSatoshis = 200;
+    const ret = await buildTransactionWithFixedFee({
+      fromWallet,
+      toWallet,
+      outputSatoshis,
+      chainType: ChainType.OPCAT,
+      targetChange: OPCAT_UTXO_DUST
+    });
+    const changeOutput = ret.psbt.txOutputs[1];
+
+    expect(ret.psbt.txOutputs.length).eq(2);
+    expect(changeOutput.address).eq(fromWallet.address);
+    expect(changeOutput.value).eq(OPCAT_UTXO_DUST);
   });
 
   it('uses the Bitcoin dust threshold by default', async function () {
@@ -87,5 +149,20 @@ describe('Transaction dust policy', function () {
     expect(ret.psbt.txOutputs.length).eq(1);
     expect(ret.psbt.txOutputs[0].value).eq(outputSatoshis);
     expect(remainingAfterFee).lt(BITCOIN_UTXO_DUST);
+  });
+
+  it('keeps Bitcoin change at the exact 546-sat threshold by default', async function () {
+    const outputSatoshis = 200;
+    const ret = await buildTransactionWithFixedFee({
+      fromWallet,
+      toWallet,
+      outputSatoshis,
+      targetChange: BITCOIN_UTXO_DUST
+    });
+    const changeOutput = ret.psbt.txOutputs[1];
+
+    expect(ret.psbt.txOutputs.length).eq(2);
+    expect(changeOutput.address).eq(fromWallet.address);
+    expect(changeOutput.value).eq(BITCOIN_UTXO_DUST);
   });
 });

--- a/packages/utils/test/transaction/dust-policy.test.ts
+++ b/packages/utils/test/transaction/dust-policy.test.ts
@@ -1,5 +1,11 @@
 import { AddressType, UnspentOutput } from '../../src';
-import { BITCOIN_UTXO_DUST, ChainType, OPCAT_UTXO_DUST, getUtxoDustThreshold } from '../../src/constants';
+import {
+  BITCOIN_UTXO_DUST,
+  ChainType,
+  OPCAT_UTXO_DUST,
+  getUtxoDustThreshold,
+  resolveChainType
+} from '../../src/constants';
 import { NetworkType } from '../../src/network';
 import { Transaction } from '../../src/transaction/transaction';
 import { LocalWallet } from '../../src/wallet';
@@ -95,6 +101,13 @@ describe('Transaction dust policy', function () {
     expect(getUtxoDustThreshold()).eq(BITCOIN_UTXO_DUST);
     expect(getUtxoDustThreshold(ChainType.BITCOIN)).eq(BITCOIN_UTXO_DUST);
     expect(getUtxoDustThreshold(ChainType.OPCAT)).eq(OPCAT_UTXO_DUST);
+  });
+
+  it('prefers explicit chain policy over the legacy OPCAT flag', function () {
+    expect(resolveChainType()).eq(ChainType.BITCOIN);
+    expect(resolveChainType({ isOpcat: true })).eq(ChainType.OPCAT);
+    expect(resolveChainType({ chainType: ChainType.OPCAT, isOpcat: false })).eq(ChainType.OPCAT);
+    expect(resolveChainType({ chainType: ChainType.BITCOIN, isOpcat: true })).eq(ChainType.BITCOIN);
   });
 
   it('keeps OPCAT small positive change instead of sweeping it to fees', async function () {

--- a/packages/utils/test/transaction/utxo.test.ts
+++ b/packages/utils/test/transaction/utxo.test.ts
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
 import { AddressType } from '../../src';
-import { BITCOIN_UTXO_DUST, OPCAT_UTXO_DUST } from '../../src/constants';
+import { BITCOIN_UTXO_DUST, ChainType, OPCAT_UTXO_DUST } from '../../src/constants';
 import { NetworkType } from '../../src/network';
 import { utxoHelper } from '../../src/transaction/utxo';
 import { LocalWallet } from '../../src/wallet';
+import { expect } from 'chai';
 
 describe('utxo', () => {
   beforeEach(() => {
@@ -11,7 +11,7 @@ describe('utxo', () => {
   });
   it('getUtxoDust', function () {
     expect(utxoHelper.getUtxoDust(AddressType.P2PKH)).to.eq(BITCOIN_UTXO_DUST);
-    expect(utxoHelper.getUtxoDust(AddressType.P2PKH, true)).to.eq(OPCAT_UTXO_DUST);
+    expect(utxoHelper.getUtxoDust(AddressType.P2PKH, ChainType.OPCAT)).to.eq(OPCAT_UTXO_DUST);
   });
 
   const networks = [
@@ -33,7 +33,7 @@ describe('utxo', () => {
           utxoHelper.getAddressUtxoDust(
             LocalWallet.fromRandom(AddressType.P2PKH, networkType).address,
             networkType,
-            true
+            ChainType.OPCAT
           )
         ).to.eq(OPCAT_UTXO_DUST);
       });

--- a/packages/utils/test/transaction/utxo.test.ts
+++ b/packages/utils/test/transaction/utxo.test.ts
@@ -12,7 +12,7 @@ describe('utxo', () => {
   });
   it('getUtxoDust', function () {
 
-    expect(utxoHelper.getUtxoDust(AddressType.P2PKH)).to.eq(546);
+    expect(utxoHelper.getUtxoDust(AddressType.P2PKH)).to.eq(1);
   });
 
   const networks = [
@@ -27,7 +27,7 @@ describe('utxo', () => {
       it('should return dust for P2PKH', function () {
         expect(
           utxoHelper.getAddressUtxoDust(LocalWallet.fromRandom(AddressType.P2PKH, networkType).address, networkType)
-        ).to.eq(546);
+        ).to.eq(1);
       });
     });
   });

--- a/packages/utils/test/transaction/utxo.test.ts
+++ b/packages/utils/test/transaction/utxo.test.ts
@@ -1,18 +1,17 @@
 import { expect } from 'chai';
-import { AddressType, UnspentOutput } from '../../src';
+import { AddressType } from '../../src';
+import { BITCOIN_UTXO_DUST, OPCAT_UTXO_DUST } from '../../src/constants';
 import { NetworkType } from '../../src/network';
 import { utxoHelper } from '../../src/transaction/utxo';
 import { LocalWallet } from '../../src/wallet';
 
 describe('utxo', () => {
-
-
   beforeEach(() => {
     // todo
   });
   it('getUtxoDust', function () {
-
-    expect(utxoHelper.getUtxoDust(AddressType.P2PKH)).to.eq(1);
+    expect(utxoHelper.getUtxoDust(AddressType.P2PKH)).to.eq(BITCOIN_UTXO_DUST);
+    expect(utxoHelper.getUtxoDust(AddressType.P2PKH, true)).to.eq(OPCAT_UTXO_DUST);
   });
 
   const networks = [
@@ -23,11 +22,20 @@ describe('utxo', () => {
   const networkNames = ['MAINNET', 'TESTNET', 'REGTEST'];
   networks.forEach((networkType) => {
     describe('getAddressUtxoDust networkType: ' + networkNames[networkType], function () {
-
       it('should return dust for P2PKH', function () {
         expect(
           utxoHelper.getAddressUtxoDust(LocalWallet.fromRandom(AddressType.P2PKH, networkType).address, networkType)
-        ).to.eq(1);
+        ).to.eq(BITCOIN_UTXO_DUST);
+      });
+
+      it('should return OPCAT dust for P2PKH when requested', function () {
+        expect(
+          utxoHelper.getAddressUtxoDust(
+            LocalWallet.fromRandom(AddressType.P2PKH, networkType).address,
+            networkType,
+            true
+          )
+        ).to.eq(OPCAT_UTXO_DUST);
       });
     });
   });

--- a/packages/utils/test/tx-helpers/send-btc.test.ts
+++ b/packages/utils/test/tx-helpers/send-btc.test.ts
@@ -1,10 +1,10 @@
-import { expect } from 'chai';
 import { AddressType, UnspentOutput } from '../../src';
 import { BITCOIN_UTXO_DUST } from '../../src/constants';
 import { ErrorCodes } from '../../src/error';
 import { NetworkType } from '../../src/network';
 import { LocalWallet } from '../../src/wallet';
 import { dummySendAllBTC, dummySendBTC, expectFeeRate, genDummyUtxo, genDummyUtxos } from './utils';
+import { expect } from 'chai';
 
 describe('sendBTC', () => {
   beforeEach(() => {

--- a/packages/utils/test/tx-helpers/send-btc.test.ts
+++ b/packages/utils/test/tx-helpers/send-btc.test.ts
@@ -1,7 +1,8 @@
 import { AddressType, UnspentOutput } from '../../src';
-import { BITCOIN_UTXO_DUST, ChainType } from '../../src/constants';
+import { BITCOIN_UTXO_DUST, ChainType, FINAL_SEQUENCE, RBF_SEQUENCE } from '../../src/constants';
 import { ErrorCodes } from '../../src/error';
 import { NetworkType } from '../../src/network';
+import { sendAllBTC, sendBTC } from '../../src/tx-helpers';
 import { LocalWallet } from '../../src/wallet';
 import { dummySendAllBTC, dummySendBTC, expectFeeRate, genDummyUtxo, genDummyUtxos } from './utils';
 import { expect } from 'chai';
@@ -60,6 +61,38 @@ describe('sendBTC', () => {
         expect(ret.outputCount).eq(1);
         expect(ret.psbt.txOutputs[0].value).eq(200);
         expect(remainingAfterFee).lt(BITCOIN_UTXO_DUST);
+      });
+
+      [
+        { enableRBF: true, expectedSequence: RBF_SEQUENCE },
+        { enableRBF: false, expectedSequence: FINAL_SEQUENCE }
+      ].forEach(({ enableRBF, expectedSequence }) => {
+        it(`applies ${enableRBF ? 'RBF' : 'final'} sequence on OPCAT send`, async function () {
+          const ret = await sendBTC({
+            btcUtxos: [genDummyUtxo(fromWallet, 10000)],
+            tos: [{ address: toWallet.address, satoshis: 1000 }],
+            networkType: fromWallet.networkType,
+            changeAddress: fromWallet.address,
+            feeRate: 1,
+            chainType: ChainType.OPCAT,
+            enableRBF
+          });
+
+          expect((ret.psbt as any).getSequence(0)).eq(expectedSequence);
+        });
+
+        it(`applies ${enableRBF ? 'RBF' : 'final'} sequence on OPCAT send-all`, async function () {
+          const ret = await sendAllBTC({
+            btcUtxos: [genDummyUtxo(fromWallet, 10000)],
+            toAddress: toWallet.address,
+            networkType: fromWallet.networkType,
+            feeRate: 1,
+            chainType: ChainType.OPCAT,
+            enableRBF
+          });
+
+          expect((ret.psbt as any).getSequence(0)).eq(expectedSequence);
+        });
       });
 
       it('send all balance', async function () {

--- a/packages/utils/test/tx-helpers/send-btc.test.ts
+++ b/packages/utils/test/tx-helpers/send-btc.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { AddressType, UnspentOutput } from '../../src';
+import { BITCOIN_UTXO_DUST } from '../../src/constants';
 import { ErrorCodes } from '../../src/error';
 import { NetworkType } from '../../src/network';
 import { LocalWallet } from '../../src/wallet';
@@ -10,9 +11,7 @@ describe('sendBTC', () => {
     // todo
   });
 
-  const testAddressTypes = [
-    AddressType.P2PKH,
-  ];
+  const testAddressTypes = [AddressType.P2PKH];
   testAddressTypes.forEach((addressType) => {
     const fromWallet = LocalWallet.fromRandom(addressType, NetworkType.MAINNET);
     const toWallet = LocalWallet.fromRandom(addressType, NetworkType.MAINNET);
@@ -31,23 +30,19 @@ describe('sendBTC', () => {
         expect(ret.psbt.txOutputs[0].value).eq(1000);
       });
 
-      it('keeps small positive change instead of sweeping it to fees', async function () {
+      it('uses the Bitcoin dust policy by default', async function () {
         const ret = await dummySendBTC({
           wallet: fromWallet,
           btcUtxos: [genDummyUtxo(fromWallet, 603)],
           tos: [{ address: toWallet.address, satoshis: 200 }],
           feeRate: 1
         });
-        const changeOutput = ret.psbt.txOutputs[1];
+        const remainingAfterFee = 603 - 200 - ret.fee;
 
         expect(ret.inputCount).eq(1);
-        expect(ret.outputCount).eq(2);
+        expect(ret.outputCount).eq(1);
         expect(ret.psbt.txOutputs[0].value).eq(200);
-        expect(changeOutput.address).eq(fromWallet.address);
-        expect(changeOutput.value).eq(603 - 200 - ret.fee);
-        expect(changeOutput.value).gt(0);
-        expect(changeOutput.value).lt(546);
-        expectFeeRate(addressType, ret.feeRate, 1);
+        expect(remainingAfterFee).lt(BITCOIN_UTXO_DUST);
       });
 
       it('send all balance', async function () {

--- a/packages/utils/test/tx-helpers/send-btc.test.ts
+++ b/packages/utils/test/tx-helpers/send-btc.test.ts
@@ -31,6 +31,25 @@ describe('sendBTC', () => {
         expect(ret.psbt.txOutputs[0].value).eq(1000);
       });
 
+      it('keeps small positive change instead of sweeping it to fees', async function () {
+        const ret = await dummySendBTC({
+          wallet: fromWallet,
+          btcUtxos: [genDummyUtxo(fromWallet, 603)],
+          tos: [{ address: toWallet.address, satoshis: 200 }],
+          feeRate: 1
+        });
+        const changeOutput = ret.psbt.txOutputs[1];
+
+        expect(ret.inputCount).eq(1);
+        expect(ret.outputCount).eq(2);
+        expect(ret.psbt.txOutputs[0].value).eq(200);
+        expect(changeOutput.address).eq(fromWallet.address);
+        expect(changeOutput.value).eq(603 - 200 - ret.fee);
+        expect(changeOutput.value).gt(0);
+        expect(changeOutput.value).lt(546);
+        expectFeeRate(addressType, ret.feeRate, 1);
+      });
+
       it('send all balance', async function () {
         const ret = await dummySendAllBTC({
           wallet: fromWallet,

--- a/packages/utils/test/tx-helpers/send-btc.test.ts
+++ b/packages/utils/test/tx-helpers/send-btc.test.ts
@@ -1,5 +1,5 @@
 import { AddressType, UnspentOutput } from '../../src';
-import { BITCOIN_UTXO_DUST } from '../../src/constants';
+import { BITCOIN_UTXO_DUST, ChainType } from '../../src/constants';
 import { ErrorCodes } from '../../src/error';
 import { NetworkType } from '../../src/network';
 import { LocalWallet } from '../../src/wallet';
@@ -36,6 +36,23 @@ describe('sendBTC', () => {
           btcUtxos: [genDummyUtxo(fromWallet, 603)],
           tos: [{ address: toWallet.address, satoshis: 200 }],
           feeRate: 1
+        });
+        const remainingAfterFee = 603 - 200 - ret.fee;
+
+        expect(ret.inputCount).eq(1);
+        expect(ret.outputCount).eq(1);
+        expect(ret.psbt.txOutputs[0].value).eq(200);
+        expect(remainingAfterFee).lt(BITCOIN_UTXO_DUST);
+      });
+
+      it('prefers chainType over the legacy OPCAT flag', async function () {
+        const ret = await dummySendBTC({
+          wallet: fromWallet,
+          btcUtxos: [genDummyUtxo(fromWallet, 603)],
+          tos: [{ address: toWallet.address, satoshis: 200 }],
+          feeRate: 1,
+          chainType: ChainType.BITCOIN,
+          isOpcat: true
         });
         const remainingAfterFee = 603 - 200 - ret.fee;
 

--- a/packages/utils/test/tx-helpers/utils.ts
+++ b/packages/utils/test/tx-helpers/utils.ts
@@ -9,12 +9,7 @@ let dummyUtxoIndex = 0;
 /**
  * generate dummy utxos
  */
-export function genDummyUtxos(
-  wallet: LocalWallet,
-  satoshisArray: number[],
-  assetsArray?: {
-  }[]
-) {
+export function genDummyUtxos(wallet: LocalWallet, satoshisArray: number[], assetsArray?: {}[]) {
   return satoshisArray.map((v, index) =>
     genDummyUtxo(wallet, satoshisArray[index], assetsArray ? assetsArray[index] : undefined)
   );
@@ -26,8 +21,7 @@ export function genDummyUtxos(
 export function genDummyUtxo(
   wallet: LocalWallet,
   satoshis: number,
-  assets?: {
-  },
+  assets?: {},
   txid?: string,
   vout?: number
 ): UnspentOutput {
@@ -37,7 +31,7 @@ export function genDummyUtxo(
     satoshis: satoshis,
     scriptPk: wallet.scriptPk,
     addressType: wallet.addressType,
-    pubkey: wallet.pubkey,
+    pubkey: wallet.pubkey
   };
 }
 
@@ -86,7 +80,7 @@ export async function dummySendBTC({
     memos
   });
 
-  await wallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any});
+  await wallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any });
   const tx = psbt.extractTransaction(true) as any;
   const txid = tx.getId();
   const inputCount = psbt.txInputs.length;
@@ -126,7 +120,7 @@ export async function dummySendAllBTC({
     enableRBF,
     networkType: wallet.networkType
   });
-  await wallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any});
+  await wallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any });
 
   const inputCount = psbt.txInputs.length;
   const outputCount = psbt.txOutputs.length;

--- a/packages/utils/test/tx-helpers/utils.ts
+++ b/packages/utils/test/tx-helpers/utils.ts
@@ -92,12 +92,13 @@ export async function dummySendBTC({
   const inputCount = psbt.txInputs.length;
   const outputCount = psbt.txOutputs.length;
   const fee = psbt.getFee();
+  const feeNumber = Number(fee);
   const virtualSize = tx.virtualSize();
-  const finalFeeRate = parseFloat((Number(fee) / virtualSize).toFixed(1));
+  const finalFeeRate = parseFloat((feeNumber / virtualSize).toFixed(1));
   if (dump) {
     printPsbt(psbt as any);
   }
-  return { psbt, txid, inputCount, outputCount, feeRate: finalFeeRate };
+  return { psbt, txid, inputCount, outputCount, fee: feeNumber, feeRate: finalFeeRate };
 }
 
 /**

--- a/packages/utils/test/tx-helpers/utils.ts
+++ b/packages/utils/test/tx-helpers/utils.ts
@@ -1,8 +1,8 @@
-import { expect } from 'chai';
 import { sendAllBTC, sendBTC } from '../../src/tx-helpers';
 import { AddressType, UnspentOutput } from '../../src/types';
 import { LocalWallet } from '../../src/wallet';
 import { printPsbt } from '../utils';
+import { expect } from 'chai';
 
 let dummyUtxoIndex = 0;
 

--- a/packages/utils/test/tx-helpers/utils.ts
+++ b/packages/utils/test/tx-helpers/utils.ts
@@ -1,4 +1,5 @@
 import { sendAllBTC, sendBTC } from '../../src/tx-helpers';
+import { ChainType } from '../../src/constants';
 import { AddressType, UnspentOutput } from '../../src/types';
 import { LocalWallet } from '../../src/wallet';
 import { printPsbt } from '../utils';
@@ -57,6 +58,8 @@ export async function dummySendBTC({
   feeRate,
   dump,
   enableRBF,
+  chainType,
+  isOpcat,
   memo,
   memos
 }: {
@@ -66,6 +69,8 @@ export async function dummySendBTC({
   feeRate: number;
   dump?: boolean;
   enableRBF?: boolean;
+  chainType?: ChainType;
+  isOpcat?: boolean;
   memo?: string;
   memos?: string[];
 }) {
@@ -76,6 +81,8 @@ export async function dummySendBTC({
     changeAddress: wallet.address,
     feeRate,
     enableRBF,
+    chainType,
+    isOpcat,
     memo,
     memos
   });
@@ -104,7 +111,9 @@ export async function dummySendAllBTC({
   toAddress,
   feeRate,
   dump,
-  enableRBF
+  enableRBF,
+  chainType,
+  isOpcat
 }: {
   wallet: LocalWallet;
   btcUtxos: UnspentOutput[];
@@ -112,12 +121,16 @@ export async function dummySendAllBTC({
   feeRate: number;
   dump?: boolean;
   enableRBF?: boolean;
+  chainType?: ChainType;
+  isOpcat?: boolean;
 }) {
   const { psbt, toSignInputs } = await sendAllBTC({
     btcUtxos,
     toAddress,
     feeRate,
     enableRBF,
+    chainType,
+    isOpcat,
     networkType: wallet.networkType
   });
   await wallet.signPsbt(psbt as any, { autoFinalized: true, toSignInputs: toSignInputs as any });


### PR DESCRIPTION
Closes #33

## Summary
- set shared OPCAT UTXO dust helpers/constants to 1 sat instead of Bitcoin Core's 546-sat policy value
- emit positive change at the 1-sat floor in the shared Transaction builder
- add regression coverage for the 603-sat input / 200-sat send case so small positive change is preserved instead of swept into fees

## Verification
- PASS: `npx tsc --noEmit -p packages/utils/tsconfig.json`
- PASS: `yarn --cwd packages/utils test --grep "keeps small positive change"`
- PASS: `cd packages/utils && npx mocha -r ./node_modules/ts-node/register test/address/address.test.ts test/transaction/utxo.test.ts test/tx-helpers/send-btc.test.ts --timeout 300000`
- FAIL: `yarn --cwd packages/utils lint` fails on pre-existing repo-wide Prettier/unused-var issues outside this scoped fix
- FAIL: `yarn --cwd packages/utils test` has 95 passing / 3 failing; failures are existing ECDSA/keyring message tests (`bitcore_lib_1.default.crypto.ECDSA is not a constructor`, plus expected `Expected Hash` vs actual `Expected Scalar`)
