### PR TITLE
feat: view CAT-721 NFT attributes on the NFT detail screen

### DIFF
--- a/packages/extension/config/jest/babelTransform.js
+++ b/packages/extension/config/jest/babelTransform.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const babelJest = require('babel-jest').default;
+
+const hasJsxRuntime = (() => {
+  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+    return false;
+  }
+
+  try {
+    require.resolve('react/jsx-runtime');
+    return true;
+  } catch (e) {
+    return false;
+  }
+})();
+
+module.exports = babelJest.createTransformer({
+  presets: [
+    [
+      require.resolve('babel-preset-react-app'),
+      {
+        runtime: hasJsxRuntime ? 'automatic' : 'classic',
+      },
+    ],
+  ],
+  babelrc: false,
+  configFile: false,
+});

--- a/packages/extension/config/jest/cssTransform.js
+++ b/packages/extension/config/jest/cssTransform.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// This is a custom Jest transformer turning style imports into empty objects.
+// http://facebook.github.io/jest/docs/en/webpack.html
+
+module.exports = {
+  process() {
+    return { code: 'module.exports = {};' };
+  },
+  getCacheKey() {
+    // The output is always the same.
+    return 'cssTransform';
+  },
+};

--- a/packages/extension/config/jest/fileTransform.js
+++ b/packages/extension/config/jest/fileTransform.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const path = require('path');
+const camelcase = require('camelcase');
+
+// This is a custom Jest transformer turning file imports into filenames.
+// http://facebook.github.io/jest/docs/en/webpack.html
+
+module.exports = {
+  process(src, filename) {
+    const assetFilename = JSON.stringify(path.basename(filename));
+
+    if (filename.match(/\.svg$/)) {
+      // Based on how SVGR generates a component name:
+      // https://github.com/smooth-code/svgr/blob/01b194cf967347d43d4cbe6b434404731b87cf27/packages/core/src/state.js#L6
+      const pascalCaseFilename = camelcase(path.parse(filename).name, {
+        pascalCase: true,
+      });
+      const componentName = `Svg${pascalCaseFilename}`;
+      return {
+        code: `const React = require('react');
+      module.exports = {
+        __esModule: true,
+        default: ${assetFilename},
+        ReactComponent: React.forwardRef(function ${componentName}(props, ref) {
+          return {
+            $$typeof: Symbol.for('react.element'),
+            type: 'svg',
+            ref: ref,
+            key: null,
+            props: Object.assign({}, props, {
+              children: ${assetFilename}
+            })
+          };
+        }),
+      };`,
+      };
+    }
+
+    return { code: `module.exports = ${assetFilename};` };
+  },
+};

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -26,6 +26,7 @@
     "fix:modules": "node scripts/fix-modules.js",
     "format": "prettier --write \"src/**/*.{js,jsx,json,md,ts,tsx}\" --plugin-search-dir=./node_modules/ --plugin=./node_modules/@trivago/prettier-plugin-sort-imports/ ",
     "prepare": "npm run fix:modules",
+    "test": "jest",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",

--- a/packages/extension/src/_locales/en/messages.json
+++ b/packages/extension/src/_locales/en/messages.json
@@ -526,6 +526,9 @@
   "collection_id": {
     "message": "Collection ID"
   },
+  "attributes": {
+    "message": "Attributes"
+  },
   "collection": {
     "message": "Collection"
   },

--- a/packages/extension/src/_locales/es/messages.json
+++ b/packages/extension/src/_locales/es/messages.json
@@ -523,6 +523,9 @@
   "collection_id": {
     "message": "Id de Colección"
   },
+  "attributes": {
+    "message": "Atributos"
+  },
   "collection": {
     "message": "Colección"
   },

--- a/packages/extension/src/_locales/fr/messages.json
+++ b/packages/extension/src/_locales/fr/messages.json
@@ -527,6 +527,9 @@
   "collection_id": {
     "message": "Id de Collection"
   },
+  "attributes": {
+    "message": "Attributs"
+  },
   "collection": {
     "message": "Collection"
   },

--- a/packages/extension/src/_locales/ja/messages.json
+++ b/packages/extension/src/_locales/ja/messages.json
@@ -525,6 +525,9 @@
   "collection_id": {
     "message": "コレクションID"
   },
+  "attributes": {
+    "message": "属性"
+  },
   "collection": {
     "message": "コレクション"
   },

--- a/packages/extension/src/_locales/ru/messages.json
+++ b/packages/extension/src/_locales/ru/messages.json
@@ -525,6 +525,9 @@
   "collection_id": {
     "message": "ID Коллекции"
   },
+  "attributes": {
+    "message": "Атрибуты"
+  },
   "collection": {
     "message": "Коллекция"
   },

--- a/packages/extension/src/_locales/zh_TW/messages.json
+++ b/packages/extension/src/_locales/zh_TW/messages.json
@@ -526,6 +526,9 @@
   "collection_id": {
     "message": "合集ID"
   },
+  "attributes": {
+    "message": "屬性"
+  },
   "collection": {
     "message": "合集"
   },

--- a/packages/extension/src/setupTests.ts
+++ b/packages/extension/src/setupTests.ts
@@ -1,0 +1,3 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// Referenced by the `setupFilesAfterEnv` entry in package.json's jest config.
+import '@testing-library/jest-dom';

--- a/packages/extension/src/ui/pages/CAT721/CAT721NFTScreen.tsx
+++ b/packages/extension/src/ui/pages/CAT721/CAT721NFTScreen.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { CAT721CollectionInfo } from '@/shared/types';
@@ -7,7 +8,10 @@ import { Line } from '@/ui/components/Line';
 import { Section } from '@/ui/components/Section';
 import { useI18n } from '@/ui/hooks/useI18n';
 import { useNavigate } from '@/ui/pages/MainRoute';
+import { useCAT721NFTContentBaseUrl } from '@/ui/state/settings/hooks';
 import { TestIds } from '@/ui/utils/test-ids';
+
+import { fetchNftTraits, NftTrait } from './nftTraits';
 
 export default function CAT721NFTScreen() {
   const { state } = useLocation();
@@ -19,6 +23,23 @@ export default function CAT721NFTScreen() {
 
   const collectionInfo = props.collectionInfo;
   const localId = props.localId;
+
+  const contentBaseUrl = useCAT721NFTContentBaseUrl();
+  const [traits, setTraits] = useState<NftTrait[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchNftTraits(contentBaseUrl, collectionInfo.collectionId, localId)
+      .then(result => {
+        if (!cancelled) setTraits(result);
+      })
+      .catch(() => {
+        if (!cancelled) setTraits([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contentBaseUrl, collectionInfo.collectionId, localId]);
 
   const navigate = useNavigate();
 
@@ -50,6 +71,23 @@ export default function CAT721NFTScreen() {
             <Section title={t('collection')} value={collectionInfo.name} />
           </Column>
         </Card>
+
+        {traits.length > 0 && (
+          <Card style={{ borderRadius: 15 }} testid={TestIds.CAT721.NFT_ATTRIBUTES}>
+            <Column fullX my="sm">
+              <Row px="md">
+                <Text text={t('attributes')} preset="bold" />
+              </Row>
+              <Line />
+              {traits.map((trait, index) => (
+                <Column key={`${trait.trait}-${index}`} gap="zero">
+                  {index > 0 && <Line />}
+                  <Section title={trait.trait} value={trait.value} />
+                </Column>
+              ))}
+            </Column>
+          </Card>
+        )}
         <Button
           preset="primary"
           text={t('send')}

--- a/packages/extension/src/ui/pages/CAT721/nftTraits.test.ts
+++ b/packages/extension/src/ui/pages/CAT721/nftTraits.test.ts
@@ -1,0 +1,44 @@
+import { extractTraits } from './nftTraits';
+
+describe('extractTraits', () => {
+  it('maps normal string attributes to traits', () => {
+    expect(
+      extractTraits({
+        attributes: [
+          { trait_type: 'Background', value: 'Blue' },
+          { trait_type: 'Eyes', value: 'Laser' }
+        ]
+      })
+    ).toEqual([
+      { trait: 'Background', value: 'Blue' },
+      { trait: 'Eyes', value: 'Laser' }
+    ]);
+  });
+
+  it('coerces numeric values to strings', () => {
+    expect(extractTraits({ attributes: [{ trait_type: 'Level', value: 42 }] })).toEqual([
+      { trait: 'Level', value: '42' }
+    ]);
+  });
+
+  it('drops entries with an empty trait_type or nullish value', () => {
+    expect(
+      extractTraits({
+        attributes: [
+          { trait_type: '', value: 'ignored' },
+          { trait_type: 'Missing', value: null },
+          { trait_type: 'NoValue' },
+          { value: 'noTraitType' } as { value: string },
+          { trait_type: 'Kept', value: 'yes' }
+        ]
+      })
+    ).toEqual([{ trait: 'Kept', value: 'yes' }]);
+  });
+
+  it('returns an empty array when metadata or attributes are missing', () => {
+    expect(extractTraits(undefined)).toEqual([]);
+    expect(extractTraits(null)).toEqual([]);
+    expect(extractTraits({})).toEqual([]);
+    expect(extractTraits({ attributes: [] })).toEqual([]);
+  });
+});

--- a/packages/extension/src/ui/pages/CAT721/nftTraits.ts
+++ b/packages/extension/src/ui/pages/CAT721/nftTraits.ts
@@ -1,0 +1,69 @@
+/**
+ * CAT-721 NFT metadata attributes (traits) helpers.
+ *
+ * Traits are fetched per-NFT from the tracker/openapi at the SAME base URL used for NFT content
+ * (see CAT721Preview) but WITHOUT the trailing `/content`:
+ *   GET {contentBaseUrl}/api/v1/collections/{collectionId}/localId/{localId}
+ *
+ * `extractTraits` is a pure function (no React / no fetch) so it can be unit-tested in isolation.
+ */
+
+export interface NftTrait {
+  trait: string;
+  value: string;
+}
+
+interface NftMetadataAttribute {
+  trait_type?: string;
+  value?: string | number | null;
+}
+
+export interface NftMetadata {
+  name?: string;
+  description?: string;
+  attributes?: NftMetadataAttribute[];
+}
+
+interface NftLocalIdInfo {
+  collectionId: string;
+  localId: string;
+  mintTxid?: string;
+  metadata?: NftMetadata;
+}
+
+interface NftLocalIdEnvelope {
+  code: number;
+  msg: string;
+  data?: NftLocalIdInfo;
+}
+
+/**
+ * Extract displayable traits from a per-NFT `metadata` blob.
+ * Keeps only entries whose `trait_type` is a non-empty string and whose `value` is non-nullish,
+ * coercing each value to a string. Returns `[]` when there are no usable attributes.
+ */
+export function extractTraits(metadata: NftMetadata | undefined | null): NftTrait[] {
+  const attrs = metadata?.attributes;
+  if (!Array.isArray(attrs)) return [];
+  return attrs
+    .filter(a => a && typeof a.trait_type === 'string' && a.trait_type !== '' && a.value != null)
+    .map(a => ({ trait: a.trait_type as string, value: String(a.value) }));
+}
+
+/**
+ * Fetch and extract the traits for a single NFT directly from the tracker/openapi.
+ * Mirrors the existing direct-fetch content pattern in CAT721Preview. Returns `[]` on any error
+ * (missing base URL, network failure, non-zero envelope code, or no usable attributes).
+ */
+export async function fetchNftTraits(
+  contentBaseUrl: string,
+  collectionId: string,
+  localId: string
+): Promise<NftTrait[]> {
+  if (!contentBaseUrl) return [];
+  const res = await fetch(`${contentBaseUrl}/api/v1/collections/${collectionId}/localId/${localId}`);
+  if (!res.ok) return [];
+  const envelope = (await res.json()) as NftLocalIdEnvelope;
+  if (!envelope || envelope.code !== 0) return [];
+  return extractTraits(envelope.data?.metadata);
+}

--- a/packages/extension/tests/e2e/token/cat721.spec.ts
+++ b/packages/extension/tests/e2e/token/cat721.spec.ts
@@ -189,6 +189,19 @@ test.describe('CAT721 NFT Operations', () => {
     // Select an NFT from the collection
     await selectNFT(page);
 
+    // If the selected NFT exposes metadata attributes (traits), the attributes
+    // section should render with at least one trait row. NFTs without usable
+    // attributes render nothing, so this assertion is conditional (non-flaky).
+    const attributesSection = page.locator(
+      `[data-testid="${TestIds.CAT721.NFT_ATTRIBUTES}"]`
+    );
+    if ((await attributesSection.count()) > 0) {
+      await expect(attributesSection).toBeVisible();
+      console.log('[DEBUG] CAT721 attributes section rendered');
+    } else {
+      console.log('[DEBUG] Selected NFT has no attributes; attributes section hidden');
+    }
+
     // Perform transfer
     const transferSuccess = await transferCAT721(page, TEST_CAT20.SATOSHI_ADDRESS);
 

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -8,7 +8,7 @@
     },
     "noImplicitAny": false,
     "downlevelIteration": true,
-    "types": ["chrome", "node", "react", "react-dom"],
+    "types": ["chrome", "node", "react", "react-dom", "jest"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## What

Adds a CAT-721 **Attributes** section to the single-NFT detail screen (`CAT721NFTScreen`), which previously showed only collection rows. Wires it to the pre-declared-but-unused `TestIds.CAT721.NFT_ATTRIBUTES`.

## How

- `src/ui/pages/CAT721/nftTraits.ts` — `extractTraits` (pure) + `fetchNftTraits`. Fetches per-NFT metadata **directly from the UI** at the same base as the NFT content (`useCAT721NFTContentBaseUrl()`), just **minus `/content`** — matching the existing `CAT721Preview` direct-fetch pattern, so no background/controller round-trip is needed. Maps the on-chain OpenSea-shaped `attributes: [{ trait_type, value }]` to `{ trait, value }` (numeric coerced to string; empty `trait_type` / null `value` dropped — same contract as the catmint backend).
- `CAT721NFTScreen.tsx` — an Attributes `Card` built from the existing `Section` / `Line` primitives, **hidden when there are no attributes**.
- i18n — `attributes` label added to all six locales (`en`, `zh_TW`, `fr`, `es`, `ru`, `ja`).

## Tests

- `nftTraits.test.ts` — unit tests for `extractTraits` (normal, numeric coercion, empty/null dropped, missing metadata).
- `tests/e2e/token/cat721.spec.ts` — conditional (non-flaky) assertion that the attributes section renders when present.

Touched files typecheck clean (0 new `tsc` errors; the repo builds via webpack/babel and CI gates on Playwright e2e, not `tsc`); unit tests green (4).

## Note

The `package.json` already had a `jest` config block, but the transform files it referenced (`config/jest/*`, `src/setupTests.ts`) were missing from the tree, so `jest` couldn't run. This PR restores those standard CRA transformers and adds a `test` script + `jest` to tsconfig types so the new unit test runs. **No new dependencies** (jest + @testing-library were already devDeps).
